### PR TITLE
Try a custom calendar component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,14 +1943,6 @@
         "webpack-bundle-analyzer": "^3.3.2",
         "webpack-cli": "^3.1.2",
         "webpack-livereload-plugin": "^2.2.0"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "npm:wp-prettier@1.19.1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-          "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
-          "dev": true
-        }
       }
     },
     "@wordpress/warning": {
@@ -3578,6 +3570,44 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-loader": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.4.2.tgz",
+      "integrity": "sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.23",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.1.1",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.0.2",
+        "schema-utils": "^2.6.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+          "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
       }
     },
     "css-select": {
@@ -6488,6 +6518,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -8474,6 +8513,18 @@
       "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
+    "mini-css-extract-plugin": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
+      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -8813,6 +8864,18 @@
       "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
     },
     "npm-package-json-lint": {
       "version": "4.6.0",
@@ -9555,6 +9618,79 @@
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+      "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.16",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+          "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
+      "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
     "postcss-reporter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
@@ -9639,6 +9775,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@1.19.1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+      "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -9851,6 +9999,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -11004,6 +11162,15 @@
         "kind-of": "^3.2.0"
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -11242,6 +11409,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
     "string-length": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "homepage": "https://github.com/Automattic/meeting-calendar#readme",
   "devDependencies": {
-    "@wordpress/scripts": "^7.1.0"
+    "@wordpress/scripts": "^7.1.0",
+    "css-loader": "^3.4.2",
+    "mini-css-extract-plugin": "^0.9.0"
   }
 }

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { format } from '@wordpress/date';
+
+function CalendarCell( { blank = false, year, month, day, events } ) {
+	if ( blank ) {
+		return <td aria-hidden />;
+	}
+
+	const date = new Date( year, month - 1, day );
+	const key = format( 'Y-m-d', date );
+	const dayEvents = events[ key ] || [];
+
+	return (
+		<td className="wporg-meeting-calendar__cell">
+			<strong>
+				<span className="screen-reader-text">
+					{ format( 'F j', date ) }
+				</span>
+				<span aria-hidden>{ day }</span>
+			</strong>
+			{ dayEvents.map( ( e ) => {
+				// Get the event date + time from the event using RFC3339 for `format`.
+				// @todo Get the recurring event time, not just first instance.
+				const eventDate = e.meta.start_date + 'T' + e.meta.time + 'Z';
+				return (
+					<h3 key={ e.id }>
+						{ format( 'g:i a: ', eventDate ) }
+						{ e.title }
+					</h3>
+				);
+			} ) }
+		</td>
+	);
+}
+
+export default CalendarCell;

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -8,7 +8,7 @@ function CalendarCell( { blank = false, year, month, day, events } ) {
 		return <td aria-hidden />;
 	}
 
-	const date = new Date( year, month - 1, day );
+	const date = new Date( year, month, day );
 	const key = format( 'Y-m-d', date );
 	const dayEvents = events[ key ] || [];
 

--- a/src/frontend/calendar/event-context.js
+++ b/src/frontend/calendar/event-context.js
@@ -1,0 +1,22 @@
+/**
+ * External Dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+const StateContext = createContext();
+
+export function EventsProvider( { children, value } ) {
+	return (
+		<StateContext.Provider value={ value }>
+			{ children }
+		</StateContext.Provider>
+	);
+}
+
+export function useEvents() {
+	const context = useContext( StateContext );
+	if ( context === undefined ) {
+		throw new Error( 'useEvents must be used within a Provider' );
+	}
+	return context;
+}

--- a/src/frontend/calendar/grid.js
+++ b/src/frontend/calendar/grid.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import CalendarCell from './cell';
+import CalendarHeader from './header';
+import { getRows, getSortedEvents } from './utils';
+import { useEvents } from './event-context';
+
+function CalendarGrid( { month, year } ) {
+	const rows = getRows( year, month );
+	const events = getSortedEvents( useEvents() );
+
+	return (
+		<table>
+			<CalendarHeader />
+			<tbody>
+				{ rows.map( ( row, i ) => (
+					<tr key={ `row-${ i }` }>
+						{ row.map( ( day, index ) => (
+							<CalendarCell
+								key={ `cell-${ index }` }
+								{ ...day }
+								events={ events }
+							/>
+						) ) }
+					</tr>
+				) ) }
+			</tbody>
+		</table>
+	);
+}
+
+export default CalendarGrid;

--- a/src/frontend/calendar/grid.js
+++ b/src/frontend/calendar/grid.js
@@ -18,7 +18,7 @@ function CalendarGrid( { month, year } ) {
 					<tr key={ `row-${ i }` }>
 						{ row.map( ( day, index ) => (
 							<CalendarCell
-								key={ `cell-${ index }` }
+								key={ `cell-${ i }-${ index }` }
 								{ ...day }
 								events={ events }
 							/>

--- a/src/frontend/calendar/header.js
+++ b/src/frontend/calendar/header.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalGetSettings } from '@wordpress/date';
+
+function CalendarHeader() {
+	const { l10n } = __experimentalGetSettings();
+	return (
+		<thead>
+			<tr>
+				{ l10n.weekdaysShort.map( ( day, i ) => {
+					return (
+						<th scope="col" key={ day }>
+							<span class="screen-reader-text">
+								{ l10n.weekdays[ i ] }
+							</span>
+							<span aria-hidden>{ day }</span>
+						</th>
+					);
+				} ) }
+			</tr>
+		</thead>
+	);
+}
+
+export default CalendarHeader;

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { date } from '@wordpress/date';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import CalendarGrid from './grid';
+import { EventsProvider } from './event-context';
+
+function Calendar( { events } ) {
+	const [ { month, year }, setDate ] = useState( { month: 2, year: 2020 } );
+
+	return (
+		<EventsProvider value={ events }>
+			<div className="wporg-meeting-calendar__header">
+				<Button
+					onClick={ () => void setDate( { month: month - 1, year } ) }
+				>
+					{ __( 'Previous', 'wordcamporg' ) }
+				</Button>
+				<h2>{ date( 'F Y', new Date( year, month - 1, 1 ) ) }</h2>
+				<Button
+					onClick={ () => void setDate( { month: month + 1, year } ) }
+				>
+					{ __( 'Next', 'wordcamporg' ) }
+				</Button>
+			</div>
+			<CalendarGrid month={ month } year={ year } />
+		</EventsProvider>
+	);
+}
+
+export default Calendar;

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -27,7 +27,7 @@ function Calendar( { events } ) {
 				>
 					{ __( 'Previous', 'wordcamporg' ) }
 				</Button>
-				<h2>{ date( 'F Y', new Date( year, month, 1 ) ) }</h2>
+				<h2 aria-live="polite" aria-atomic>{ date( 'F Y', new Date( year, month, 1 ) ) }</h2>
 				<Button
 					onClick={ () => void setDate( { month: month + 1, year } ) }
 				>

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -13,7 +13,11 @@ import CalendarGrid from './grid';
 import { EventsProvider } from './event-context';
 
 function Calendar( { events } ) {
-	const [ { month, year }, setDate ] = useState( { month: 2, year: 2020 } );
+	const today = new Date();
+	const [ { month, year }, setDate ] = useState( {
+		month: today.getMonth(),
+		year: today.getFullYear(),
+	} );
 
 	return (
 		<EventsProvider value={ events }>
@@ -23,7 +27,7 @@ function Calendar( { events } ) {
 				>
 					{ __( 'Previous', 'wordcamporg' ) }
 				</Button>
-				<h2>{ date( 'F Y', new Date( year, month - 1, 1 ) ) }</h2>
+				<h2>{ date( 'F Y', new Date( year, month, 1 ) ) }</h2>
 				<Button
 					onClick={ () => void setDate( { month: month + 1, year } ) }
 				>

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { format } from '@wordpress/date';
+
+// Default value for days not in this month.
+const emptyDate = {
+	blank: true,
+};
+
+/**
+ * Get days in the given month in a 2-dimensional array of [week][day].
+ *
+ * @param {number} year
+ * @param {number} month
+ */
+export function getRows( year, month ) {
+	const daysInWeek = 7;
+	const firstOffset = new Date( year, month - 1, 1 ).getDay(); // Get day of the week.
+	const monthLength = new Date( year, month, 0 ).getDate(); // 0 gets the last day of the next month.
+	const days = [];
+
+	for ( let i = 0; i < firstOffset; i++ ) {
+		days.push( emptyDate );
+	}
+	for ( let i = 1; i <= monthLength; i++ ) {
+		days.push( {
+			month,
+			year,
+			day: i,
+		} );
+	}
+
+	const rows = [];
+	for ( let i = 0; i < Math.ceil( days.length / daysInWeek ); i++ ) {
+		const start = i * daysInWeek;
+		let row = days.slice( start, start + daysInWeek );
+		if ( row.length !== daysInWeek ) {
+			row = [
+				...row,
+				...Array( daysInWeek - row.length ).fill( emptyDate ),
+			];
+		}
+		rows.push( row );
+	}
+
+	return rows;
+}
+
+/**
+ * Get the list of events in day-buckets.
+ *
+ * @param {Array} events
+ */
+export function getSortedEvents( events ) {
+	const sortedEvents = {};
+	events.forEach( ( event ) => {
+		const key = format( 'Y-m-d', event.start );
+		if ( sortedEvents.hasOwnProperty( key ) ) {
+			sortedEvents[ key ].push( event );
+		} else {
+			sortedEvents[ key ] = [ event ];
+		}
+	} );
+	return sortedEvents;
+}

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -16,8 +16,8 @@ const emptyDate = {
  */
 export function getRows( year, month ) {
 	const daysInWeek = 7;
-	const firstOffset = new Date( year, month - 1, 1 ).getDay(); // Get day of the week.
-	const monthLength = new Date( year, month, 0 ).getDate(); // 0 gets the last day of the next month.
+	const firstOffset = new Date( year, month, 1 ).getDay(); // Get day of the week.
+	const monthLength = new Date( year, month + 1, 0 ).getDate(); // 0 gets the last day of the next month.
 	const days = [];
 
 	for ( let i = 0; i < firstOffset; i++ ) {

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { createElement, render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Calendar from './calendar';
+import './styles.css';
+
+const getMeetings = ( calendarEl ) => {
+	return JSON.parse( calendarEl.getAttribute( 'data-meetings' ) );
+};
+
+const formatMeeting = ( i ) => {
+	return {
+		...i,
+		title: i.title.rendered,
+		start: i.meta.start_date,
+	};
+};
+
+const initCalendar = () => {
+	const calendarEl = document.getElementById( 'wporg-meeting-calendar-js' );
+	const events = getMeetings( calendarEl ).map( formatMeeting );
+
+	render( createElement( Calendar, { events } ), calendarEl );
+};
+
+document.addEventListener( 'DOMContentLoaded', initCalendar );

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -1,0 +1,41 @@
+.wporg-block-meeting-calendar {
+	margin: 0 auto;
+}
+
+.wporg-block-meeting-calendar table {
+	table-layout: fixed;
+	margin-bottom: 0; /* There is a global style that is adding a bottom margin to tables */
+}
+
+.wporg-meeting-calendar__header {
+	display: flex;
+	align-items: center;
+}
+
+.wporg-meeting-calendar__header h2 {
+	flex: 1;
+	text-align: center;
+}
+
+.wporg-meeting-calendar__header h2:before {
+	display: none;
+}
+
+.wporg-meeting-calendar__cell {
+	padding: 12px;
+	vertical-align: top;
+	height: 5em; /* height acts as min-height on table cells */
+}
+
+.wporg-meeting-calendar__cell strong {
+	display: block;
+	margin: -12px -12px 0;
+	padding: 6px 12px;
+	font-size: 0.8em;
+	background: #ddd;
+}
+
+.wporg-meeting-calendar__cell h3 {
+	font-size: 0.8em;
+	font-weight: normal;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
-// eslint-disable-next-line no-undef
-import { registerBlockType } from '@wordpress/blocks'
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
-import save from './save';
 
 registerBlockType( 'a8c-meeting-calendar/main', {
 	title: 'Meeting Calendar',
@@ -13,5 +14,5 @@ registerBlockType( 'a8c-meeting-calendar/main', {
 	category: 'widgets',
 	attributes: {},
 	edit,
-	save,
+	save: () => null,
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import edit from './edit';
 
-registerBlockType( 'a8c-meeting-calendar/main', {
+registerBlockType( 'wporg-meeting-calendar/main', {
 	title: 'Meeting Calendar',
 	icon: 'calendar',
 	category: 'widgets',

--- a/src/save.js
+++ b/src/save.js
@@ -1,5 +1,0 @@
-const SaveView = () => {
-	return <div>The backend is alive</div>;
-};
-
-export default SaveView;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,30 @@
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+const path = require( 'path' );
+
+module.exports = {
+	...defaultConfig,
+	entry: {
+		...defaultConfig.entry,
+		calendar: path.resolve(
+			__dirname,
+			'src/frontend/index.js'
+		),
+	},
+	module: {
+		...defaultConfig.module,
+		rules: [
+			...defaultConfig.module.rules,
+			{
+				test: /\.css$/,
+				use: [ MiniCssExtractPlugin.loader, 'css-loader' ],
+			},
+		],
+	},
+	plugins: [
+		...defaultConfig.plugins,
+		new MiniCssExtractPlugin( {
+			filename: '[name].css',
+		} ),
+	],
+};


### PR DESCRIPTION
This is a very simple table-based calendar with basic event rendering. Uses the same event-loading code from #6, but instead of FullCalendar, this uses a custom React `<Calendar />` component. This supports accessibility/screen reader users out of the box, by using semantic HTML & `screen-reader-text` elements so that users get the same information whether they can see the calendar layout or not.

Currently only a month-view, but a week/day view could be introduced. Not responsive, but could be added (using [`@wordpress/viewport`](https://github.com/WordPress/gutenberg/tree/master/packages/viewport) maybe).

_I ended up taking this approach, even though we said we didn't want to roll our own, because creating an accessible view for FullCalendar would have been more work, with almost no examples or documentation to follow._

I've been testing on a regular WP install, so this uses Twenty Nineteen styles— CSS for wp.org will probably need to be tweaked a bunch :)

![Screen Shot 2020-02-23 at 1 59 47 PM](https://user-images.githubusercontent.com/541093/75118253-8a86a200-5646-11ea-87ce-47488cb2c0ff.png)

**To test**

- View the page with the block
- You should see a rendered calendar, with the current meetings
- You can move forward & backward to see other months
- Try testing with a screen reader (here's [an intro to VoiceOver,](https://webaim.org/articles/voiceover/) test in Safari if you try this)
