### PR TITLE
Add in today, month and list buttons to header

### DIFF
--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, ButtonGroup } from '@wordpress/components';
 import { date } from '@wordpress/date';
 import { useState } from '@wordpress/element';
 
@@ -14,27 +14,47 @@ import { EventsProvider } from './event-context';
 
 function Calendar( { events } ) {
 	const today = new Date();
-	const [ { month, year }, setDate ] = useState( {
-		month: today.getMonth(),
-		year: today.getFullYear(),
-	} );
+	const currentMonth = today.getMonth();
+	const currentYear = today.getFullYear();
+	const currentMonthYear = {
+		month: currentMonth,
+		year: currentYear,
+	};
+	const [ { month, year }, setDate ] = useState( currentMonthYear );
 
 	return (
 		<EventsProvider value={ events }>
 			<div className="wporg-meeting-calendar__header">
-				<Button
-					onClick={ () => void setDate( { month: month - 1, year } ) }
-				>
-					{ __( 'Previous', 'wordcamporg' ) }
-				</Button>
-				<h2 aria-live="polite" aria-atomic>
-					{ date( 'F Y', new Date( year, month, 1 ) ) }
-				</h2>
-				<Button
-					onClick={ () => void setDate( { month: month + 1, year } ) }
-				>
-					{ __( 'Next', 'wordcamporg' ) }
-				</Button>
+				<div className="wporg-meeting-calendar__btn-group">
+					<Button onClick={ () => void setDate( currentMonthYear ) }>
+						{ __( 'Today', 'wporg' ) }
+					</Button>
+					<Button
+						onClick={ () =>
+							void setDate( { month: month - 1, year } )
+						}
+					>
+						{ __( 'Previous', 'wporg' ) }
+					</Button>
+					<Button
+						onClick={ () =>
+							void setDate( { month: month + 1, year } )
+						}
+					>
+						{ __( 'Next', 'wporg' ) }
+					</Button>
+				</div>
+				<div>
+					<h2 aria-live="polite" aria-atomic>
+						{ date( 'F Y', new Date( year, month, 1 ) ) }
+					</h2>
+				</div>
+				<div>
+					<ButtonGroup>
+						<Button>{ __( 'Month', 'wporg' ) }</Button>
+						<Button>{ __( 'List', 'wporg' ) }</Button>
+					</ButtonGroup>
+				</div>
 			</div>
 			<CalendarGrid month={ month } year={ year } />
 		</EventsProvider>

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -49,12 +49,10 @@ function Calendar( { events } ) {
 						{ date( 'F Y', new Date( year, month, 1 ) ) }
 					</h2>
 				</div>
-				<div>
-					<ButtonGroup>
-						<Button>{ __( 'Month', 'wporg' ) }</Button>
-						<Button>{ __( 'List', 'wporg' ) }</Button>
-					</ButtonGroup>
-				</div>
+				<ButtonGroup>
+					<Button>{ __( 'Month', 'wporg' ) }</Button>
+					<Button>{ __( 'List', 'wporg' ) }</Button>
+				</ButtonGroup>
 			</div>
 			<CalendarGrid month={ month } year={ year } />
 		</EventsProvider>

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -21,7 +21,6 @@
 }
 
 .wporg-meeting-calendar__header h2 {
-	flex: 1;
 	text-align: center;
 }
 

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -12,6 +12,14 @@
 	align-items: center;
 }
 
+.wporg-meeting-calendar__header div {
+	flex: 1 1 0;
+}
+
+.wporg-meeting-calendar__header div:last-child {
+	text-align: right;
+}
+
 .wporg-meeting-calendar__header h2 {
 	flex: 1;
 	text-align: center;
@@ -38,4 +46,12 @@
 .wporg-meeting-calendar__cell h3 {
 	font-size: 0.8em;
 	font-weight: normal;
+}
+
+.wporg-meeting-calendar__btn-group button {
+	margin-right: 6px;
+}
+
+.wporg-meeting-calendar__btn-group button:last-child {
+	margin-right: 0;
 }


### PR DESCRIPTION
This PR adds to the header:
- Today Button (implemented/we can play with its exact location)
- `Month` & `List` View Buttons (functionality no implemented)
- Moves `Previous` & `Next` beside each other for context (modelling google calendar)
## Question
Are we good with these as the base feature set?

**Note: The button styles are not getting picked up on my env.**

![Screenshot](https://d.pr/i/9FncoS.png)
