### PR TITLE
Add/support multiple occurrences

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -23,6 +23,7 @@ class Meeting_Post_Type {
 		$mpt = Meeting_Post_Type::getInstance();
 		add_action( 'init',                               array( $mpt, 'register_meeting_post_type' ) );
 		add_action( 'init',                               array( $mpt, 'register_meta' ) );
+		add_action( 'rest_api_init',                      array( $mpt, 'register_rest_field' ) );
 		add_action( 'save_post_meeting',                  array( $mpt, 'save_meta_boxes' ), 10, 2 );
 		add_filter( 'pre_get_posts',                      array( $mpt, 'meeting_archive_page_query' ) );
 		add_filter( 'the_posts',                          array( $mpt, 'meeting_set_next_meeting' ), 10, 2 );
@@ -82,88 +83,11 @@ class Meeting_Post_Type {
 
 		// for each entry, set a fake meta value to show the next date for recurring meetings
 		array_walk( $posts, function ( &$post ) {
-			if ( 'weekly' === $post->recurring || '1' === $post->recurring ) {
-				try {
-					// from the start date, advance the week until it's past now
-					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-					$next  = $start;
-					// minus 30 minutes to account for currently ongoing meetings
-					$now   = new DateTime( '-30 minutes' );
-
-					if ( $next < $now ) {
-						$interval = $start->diff( $now );
-						// add one to days to account for events that happened earlier today
-						$weekdiff = ceil( ( $interval->days + 1 ) / 7 );
-						$next->modify( '+ ' . $weekdiff . ' weeks' );
-					}
-
-					$post->next_date = $next->format( 'Y-m-d' );
-				} catch ( Exception $e ) {
-					// if the datetime is invalid, then set the post->next_date to the start date instead
-					$post->next_date = $post->start_date;
-				}
-			} else if ( 'biweekly' === $post->recurring ) {
-				try {
-					// advance the start date 2 weeks at a time until it's past now
-					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-					$next  = $start;
-					// minus 30 minutes to account for currently ongoing meetings
-					$now   = new DateTime( '-30 minutes' );
-
-					while ( $next < $now ) {
-						$next->modify( '+2 weeks' );
-					}
-
-					$post->next_date = $next->format( 'Y-m-d' );
-				} catch ( Exception $e ) {
-					// if the datetime is invalid, then set the post->next_date to the start date instead
-					$post->next_date = $post->start_date;
-				}
-			} else if ( 'occurrence' === $post->recurring ) {
-				try {
-					// advance the occurrence day in the current month until it's past now
-					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-					$next  = $start;
-					// minus 30 minutes to account for currently ongoing meetings
-					$now   = new DateTime( '-30 minutes' );
-
-					$day_index = date( 'w', strtotime( sprintf( '%s %s GMT', $post->start_date, $post->time ) ) );
-					$day_name  = $GLOBALS['wp_locale']->get_weekday( $day_index );
-					$numerals  = array( 'first', 'second', 'third', 'fourth' );
-					$months    = array( 'this month', 'next month' );
-
-					foreach ( $months as $month ) {
-						foreach ( $post->occurrence as $index ) {
-							$next = new DateTime( sprintf( '%s %s of %s %s GMT', $numerals[ $index - 1 ], $day_name, $month, $post->time ) );
-							if ( $next > $now ) {
-								break 2;
-							}
-						}
-					}
-
-					$post->next_date = $next->format( 'Y-m-d' );
-				} catch ( Exception $e ) {
-					// if the datetime is invalid, then set the post->next_date to the start date instead
-					$post->next_date = $post->start_date;
-				}
-			} else if ( 'monthly' === $post->recurring ) {
-				try {
-					// advance the start date 1 month at a time until it's past now
-					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-					$next  = $start;
-					// minus 30 minutes to account for currently ongoing meetings
-					$now   = new DateTime( '-30 minutes' );
-
-					while ( $next < $now ) {
-						$next->modify( '+1 month' );
-					}
-
-					$post->next_date = $next->format( 'Y-m-d' );
-				} catch ( Exception $e ) {
-					// if the datetime is invalid, then set the post->next_date to the start date instead
-					$post->next_date = $post->start_date;
-				}
+			$next = $this->get_next_occurrence( $post );
+			if ( $next ) {
+				$post->next_date = $next;
 			} else {
+				// if the datetime is invalid, then set the post->next_date to the start date instead
 				$post->next_date = $post->start_date;
 			}
 		});
@@ -179,6 +103,104 @@ class Meeting_Post_Type {
 		});
 
 		return $posts;
+	}
+
+	/*
+	 * Returns the date of the next occurrence of the meeting.
+	 *
+	 * @param object $post A meeting post object.
+	 * @param string $after_datetime Find the next occurrence after this date.
+	 *
+	 * @return string|bool A date string representing the date of the next occurrence; false if there is no next meeting.
+	 */
+	function get_next_occurrence( $post, $after_datetime = '-30 minutes' ) {
+		if ( !is_object( $post ) || 'meeting' !== $post->post_type )
+			return false;
+
+		$next_date = false;
+
+		if ( 'weekly' === $post->recurring || '1' === $post->recurring ) {
+			try {
+				// from the start date, advance the week until it's past now
+				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+				$next  = $start;
+				// minus 30 minutes to account for currently ongoing meetings
+				$now   = new DateTime( $after_datetime );
+
+				if ( $next <= $now ) {
+					$interval = $start->diff( $now );
+					// add one to days to account for events that happened earlier today
+					$weekdiff = ceil( ( $interval->days + 1 ) / 7 );
+					$next->modify( '+ ' . $weekdiff . ' weeks' );
+				}
+
+				$next_date = $next->format( 'Y-m-d' );
+			} catch ( Exception $e ) {
+				$next_date = false;
+			}
+		} else if ( 'biweekly' === $post->recurring ) {
+			try {
+				// advance the start date 2 weeks at a time until it's past now
+				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+				$next  = $start;
+				// minus 30 minutes to account for currently ongoing meetings
+				$now   = new DateTime( $after_datetime );
+
+				while ( $next <= $now ) {
+					$next->modify( '+2 weeks' );
+				}
+
+				$next_date = $next->format( 'Y-m-d' );
+			} catch ( Exception $e ) {
+				$next_date = false;
+			}
+		} else if ( 'occurrence' === $post->recurring ) {
+			try {
+				// advance the occurrence day in the current month until it's past now
+				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+				$next  = $start;
+				// minus 30 minutes to account for currently ongoing meetings
+				$now   = new DateTime( $after_datetime );
+
+				$day_index = date( 'w', strtotime( sprintf( '%s %s GMT', $post->start_date, $post->time ) ) );
+				$day_name  = $GLOBALS['wp_locale']->get_weekday( $day_index );
+				$numerals  = array( 'first', 'second', 'third', 'fourth' );
+				$months    = array( 'this month', 'next month' );
+
+				foreach ( $months as $month ) {
+					foreach ( $post->occurrence as $index ) {
+						$next = new DateTime( sprintf( '%s %s of %s %s GMT', $numerals[ $index - 1 ], $day_name, $month, $post->time ) );
+						if ( $next > $now ) {
+							break 2;
+						}
+					}
+				}
+
+				$next_date = $next->format( 'Y-m-d' );
+			} catch ( Exception $e ) {
+				$next_date = false;
+			}
+		} else if ( 'monthly' === $post->recurring ) {
+			try {
+				// advance the start date 1 month at a time until it's past now
+				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+				$next  = $start;
+				// minus 30 minutes to account for currently ongoing meetings
+				$now   = new DateTime( $after_datetime );
+
+				while ( $next <= $now ) {
+					$next->modify( '+1 month' );
+				}
+
+				$next_date = $next->format( 'Y-m-d' );
+			} catch ( Exception $e ) {
+				$next_date = false;
+			}
+		} else {
+			$next_date = $post->start_date;
+		}
+
+		return $next_date;
 	}
 
 	public function register_meeting_post_type() {
@@ -263,6 +285,34 @@ class Meeting_Post_Type {
 				),
 			)
 		);
+	}
+
+	public function register_rest_field() {
+		register_rest_field( 'meeting', 'future_occurrences', array(
+			'get_callback' => array( $this, 'get_future_occurrences' )
+			)
+		);	
+	}
+
+	public function get_future_occurrences( $meeting ) {
+		if ( is_array( $meeting ) && !empty( $meeting['id'] ) ) {
+			// The register_rest_field callback passes a prepared array but we need the post object
+			$meeting = get_post( $meeting['id'] );
+		}
+
+		$from = new DateTime( '-30 minutes' );
+		$end = new DateTime( '+1 month' );
+		$max = 12;
+		$occurrences = array();
+		do {
+			$next = $this->get_next_occurrence( $meeting, $from->format( 'Y-m-d H:i:s P' ) );
+			if ( $next ) {
+				$occurrences[] = $next;
+				$from = new DateTime( "{$next} {$meeting->time}" );
+			}
+		} while ( --$max > 0 && $next && $from && $from < $end );
+
+		return $occurrences;
 	}
 
 	public function add_meta_boxes() {

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -165,7 +165,7 @@ class Meeting_Post_Type {
 				$day_index = date( 'w', strtotime( sprintf( '%s %s GMT', $post->start_date, $post->time ) ) );
 				$day_name  = $GLOBALS['wp_locale']->get_weekday( $day_index );
 				$numerals  = array( 'first', 'second', 'third', 'fourth' );
-				$months    = array( 'this month', 'next month' );
+				$months    = array( 'this month', 'next month', "+2 month" );
 
 				foreach ( $months as $month ) {
 					foreach ( $post->occurrence as $index ) {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -65,6 +65,32 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( 'weekly',        $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
 		$this->assertEquals( array(),         $meeting['meta']['occurrence'] );
+
+		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
+		$this->assertEquals( 5, count( $meeting['future_occurrences'] ) );
+		// There should be no duplicates
+		$this->assertEquals( $meeting['future_occurrences'], array_unique( $meeting['future_occurrences'] ) );
+		$last = false;
+		foreach ( $meeting['future_occurrences'] as $future_date ) {
+			// Make sure it's in the expected date format
+			$this->assertEquals( 1, preg_match( '/^(\d\d\d\d)-(\d\d)-(\d\d)$/', $future_date, $matches ) );
+			// And it's a valid date
+			$this->assertTrue( checkdate( $matches[2], $matches[3], $matches[1] ) );
+
+			$dt = new DateTime( $future_date );
+			// It should be in the future
+			$this->assertGreaterThanOrEqual( new DateTime(), $dt );
+			// Day of week should be Wednesday, same as the original
+			$this->assertEquals( 3, $dt->format( 'N' ) );
+
+			if ( $last ) {
+				$interval = $last->diff( $dt );
+				// Should be exactly 7 days after the prior date
+				$this->assertEquals( '+7 days', $interval->format( '%R%a days' ) );
+			}
+
+			$last = $dt;
+		}
 	}
 
 	public function test_meeting_monthly() {
@@ -82,6 +108,32 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( 'monthly',       $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
 		$this->assertEquals( array(),         $meeting['meta']['occurrence'] );
+
+		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
+		$this->assertEquals( 2, count( $meeting['future_occurrences'] ) );
+		// There should be no duplicates
+		$this->assertEquals( $meeting['future_occurrences'], array_unique( $meeting['future_occurrences'] ) );
+		$last = false;
+		foreach ( $meeting['future_occurrences'] as $future_date ) {
+			// Make sure it's in the expected date format
+			$this->assertEquals( 1, preg_match( '/^(\d\d\d\d)-(\d\d)-(\d\d)$/', $future_date, $matches ) );
+			// And it's a valid date
+			$this->assertTrue( checkdate( $matches[2], $matches[3], $matches[1] ) );
+
+			$dt = new DateTime( $future_date );
+			// It should be in the future
+			$this->assertGreaterThanOrEqual( new DateTime(), $dt );
+			// Day of week should be the first of the month, same as the original
+			$this->assertEquals( 1, $dt->format( 'd' ) );
+
+			if ( $last ) {
+				$interval = $last->diff( $dt );
+				// Should be exactly 7 days after the prior date
+				$this->assertEquals( '+1 month 0 days', $interval->format( '%R%m month %d days' ) );
+			}
+
+			$last = $dt;
+		}
 	}
 
 	public function test_meeting_third_wednesday() {
@@ -99,6 +151,33 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( 'occurrence',    $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
 		$this->assertEquals( array(3),        $meeting['meta']['occurrence'] );
+
+		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
+		$this->assertEquals( 5, count( $meeting['future_occurrences'] ) );
+		// There should be no duplicates
+		$this->assertEquals( $meeting['future_occurrences'], array_unique( $meeting['future_occurrences'] ) );
+		$last = false;
+		foreach ( $meeting['future_occurrences'] as $future_date ) {
+			// Make sure it's in the expected date format
+			$this->assertEquals( 1, preg_match( '/^(\d\d\d\d)-(\d\d)-(\d\d)$/', $future_date, $matches ) );
+			// And it's a valid date
+			$this->assertTrue( checkdate( $matches[2], $matches[3], $matches[1] ) );
+
+			$dt = new DateTime( $future_date );
+			// It should be in the future
+			$this->assertGreaterThanOrEqual( new DateTime(), $dt );
+
+			// Day of week should be Wednesday, same as the original
+			$this->assertEquals( 3, $dt->format( 'N' ) );
+
+			if ( $last ) {
+				$interval = $last->diff( $dt );
+				// Should be exactly 7 days after the prior date
+				$this->assertEquals( '+7 days', $interval->format( '%R%a days' ) );
+			}
+
+			$last = $dt;
+		}
 	}
 
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -153,7 +153,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( array(3),        $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
-		$this->assertEquals( 5, count( $meeting['future_occurrences'] ) );
+		$this->assertEquals( 2, count( $meeting['future_occurrences'] ) );
 		// There should be no duplicates
 		$this->assertEquals( $meeting['future_occurrences'], array_unique( $meeting['future_occurrences'] ) );
 		$last = false;
@@ -172,8 +172,9 @@ class MeetingAPITest extends WP_UnitTestCase {
 
 			if ( $last ) {
 				$interval = $last->diff( $dt );
-				// Should be exactly 7 days after the prior date
-				$this->assertEquals( '+7 days', $interval->format( '%R%a days' ) );
+				// Should be between 28 and 31 days since the last meeting
+				$this->assertGreaterThanOrEqual( 28, $interval->format( '%R%a' ) );
+				$this->assertLessThanOrEqual( 31, $interval->format( '%R%a' ) );
 			}
 
 			$last = $dt;


### PR DESCRIPTION
This adds API support for returning the future occurrences of each meeting. Future dates will be listed in the `future_occurrences` array. Currently it will only include occurrences within the next month (approximately).
