### PR TITLE
Add new API route

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -308,16 +308,17 @@ class Meeting_Post_Type {
 			$occurrences = $this->get_future_occurrences( $meeting, null, $request );
 			foreach ( $occurrences as $occurrence ) {
 				$out[] = array(
-					'meeting_id' => $meeting->ID,
-					'date'       => $occurrence,
-					'time'       => $meeting->time,
-					'datetime'   => "{$occurrence}T{$meeting->time}+00:00",
-					'team'       => $meeting->team,
-					'link'       => $meeting->link,
-					'title'      => $meeting->post_title,
-					'recurring'  => $meeting->recurring,
-					'occurrence' => $meeting->occurrence,
-					'status'     => 'active', // TODO: support 'cancelled'
+					'meeting_id'  => $meeting->ID,
+					'instance_id' => "{$meeting->ID}:{$occurrence}",
+					'date'        => $occurrence,
+					'time'        => $meeting->time,
+					'datetime'    => "{$occurrence}T{$meeting->time}+00:00",
+					'team'        => $meeting->team,
+					'link'        => $meeting->link,
+					'title'       => $meeting->post_title,
+					'recurring'   => $meeting->recurring,
+					'occurrence'  => $meeting->occurrence,
+					'status'      => 'active', // TODO: support 'cancelled'
 				);
 			}
 		}

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -300,8 +300,6 @@ class Meeting_Post_Type {
 	}
 
 	public function get_occurrences_for_period( $request ) {
-		var_dump( $request->get_param('month') );
-
 		$meetings = get_posts( array( 'post_type' => 'meeting', 'numberposts' => -1 ) );
 		$out = array();
 		foreach ( $meetings as $meeting ) {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -348,7 +348,31 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$meetings = $response->get_data();
 
-		#$this->assertEquals( $this->_january_meetings(), $meetings );
+		$expected_datetimes = array (
+		  0 => '2020-02-01T15:00:00+00:00',
+		  1 => '2020-02-05T14:00:00+00:00',
+		  2 => '2020-02-12T14:00:00+00:00',
+		  3 => '2020-02-19T14:00:00+00:00',
+		  4 => '2020-02-19T16:00:00+00:00',
+		  5 => '2020-02-26T14:00:00+00:00',
+		  6 => '2020-03-01T15:00:00+00:00',
+		  7 => '2020-03-04T14:00:00+00:00',
+		  8 => '2020-03-18T16:00:00+00:00',
+		);
+		$this->assertEquals( $expected_datetimes, wp_list_pluck( $meetings, 'datetime' ) );
+
+		$expected_teams = array (
+		  0 => 'Team-B',
+		  1 => 'Team-A',
+		  2 => 'Team-A',
+		  3 => 'Team-A',
+		  4 => 'Team-C',
+		  5 => 'Team-A',
+		  6 => 'Team-B',
+		  7 => 'Team-A',
+		  8 => 'Team-C',
+		);
+		$this->assertEquals( $expected_teams, wp_list_pluck( $meetings, 'team' ) );
 
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -25,6 +25,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 
 		// Make sure the meta keys are registered - setUp/tearDown nukes these
 		Meeting_Post_Type::getInstance()->register_meta();
+		Meeting_Post_Type::getInstance()->register_rest_routes();
 
 	}
 
@@ -181,5 +182,156 @@ class MeetingAPITest extends WP_UnitTestCase {
 		}
 	}
 
+	public function _january_meetings() {
+		return array (
+		  0 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'date' => '2020-01-01',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-01-01T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  1 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[1],
+		    'date' => '2020-01-01',
+		    'time' => '15:00:00',
+		    'datetime' => '2020-01-01T15:00:00+00:00',
+		    'team' => 'Team-B',
+		    'link' => 'wordpress.org',
+		    'title' => 'A monthly meeting',
+		    'recurring' => 'monthly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  2 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'date' => '2020-01-08',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-01-08T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  3 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'date' => '2020-01-15',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-01-15T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  4 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[2],
+		    'date' => '2020-01-15',
+		    'time' => '16:00:00',
+		    'datetime' => '2020-01-15T16:00:00+00:00',
+		    'team' => 'Team-C',
+		    'link' => 'wordpress.org',
+		    'title' => 'Third Wednesday of each month',
+		    'recurring' => 'occurrence',
+		    'occurrence' => 
+		    array (
+		      0 => 3,
+		    ),
+		    'status' => 'active',
+		  ),
+		  5 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'date' => '2020-01-22',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-01-22T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  6 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'date' => '2020-01-29',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-01-29T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  7 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[1],
+		    'date' => '2020-02-01',
+		    'time' => '15:00:00',
+		    'datetime' => '2020-02-01T15:00:00+00:00',
+		    'team' => 'Team-B',
+		    'link' => 'wordpress.org',
+		    'title' => 'A monthly meeting',
+		    'recurring' => 'monthly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  8 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'date' => '2020-02-05',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-02-05T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  9 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[2],
+		    'date' => '2020-02-19',
+		    'time' => '16:00:00',
+		    'datetime' => '2020-02-19T16:00:00+00:00',
+		    'team' => 'Team-C',
+		    'link' => 'wordpress.org',
+		    'title' => 'Third Wednesday of each month',
+		    'recurring' => 'occurrence',
+		    'occurrence' => 
+		    array (
+		      0 => 3,
+		    ),
+		    'status' => 'active',
+		  ),
+		);
+	}
+
+	public function test_meetings_january_2020() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$meetings = $response->get_data();
+
+		$this->assertEquals( $this->_january_meetings(), $meetings );
+
+
+	}
 
 }

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -187,6 +187,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  0 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-01-01',
 		    'date' => '2020-01-01',
 		    'time' => '14:00:00',
 		    'datetime' => '2020-01-01T14:00:00+00:00',
@@ -200,6 +201,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  1 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[1],
+		    'instance_id' => $this->meeting_ids[1] . ':2020-01-01',
 		    'date' => '2020-01-01',
 		    'time' => '15:00:00',
 		    'datetime' => '2020-01-01T15:00:00+00:00',
@@ -213,6 +215,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  2 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-01-08',
 		    'date' => '2020-01-08',
 		    'time' => '14:00:00',
 		    'datetime' => '2020-01-08T14:00:00+00:00',
@@ -226,6 +229,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  3 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-01-15',
 		    'date' => '2020-01-15',
 		    'time' => '14:00:00',
 		    'datetime' => '2020-01-15T14:00:00+00:00',
@@ -239,6 +243,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  4 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[2],
+		    'instance_id' => $this->meeting_ids[2] . ':2020-01-15',
 		    'date' => '2020-01-15',
 		    'time' => '16:00:00',
 		    'datetime' => '2020-01-15T16:00:00+00:00',
@@ -255,6 +260,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  5 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-01-22',
 		    'date' => '2020-01-22',
 		    'time' => '14:00:00',
 		    'datetime' => '2020-01-22T14:00:00+00:00',
@@ -268,6 +274,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  6 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-01-29',
 		    'date' => '2020-01-29',
 		    'time' => '14:00:00',
 		    'datetime' => '2020-01-29T14:00:00+00:00',
@@ -281,6 +288,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  7 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[1],
+		    'instance_id' => $this->meeting_ids[1] . ':2020-02-01',
 		    'date' => '2020-02-01',
 		    'time' => '15:00:00',
 		    'datetime' => '2020-02-01T15:00:00+00:00',
@@ -294,6 +302,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  8 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-02-05',
 		    'date' => '2020-02-05',
 		    'time' => '14:00:00',
 		    'datetime' => '2020-02-05T14:00:00+00:00',
@@ -307,6 +316,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  9 => 
 		  array (
 		    'meeting_id' => $this->meeting_ids[2],
+		    'instance_id' => $this->meeting_ids[2] . ':2020-02-19',
 		    'date' => '2020-02-19',
 		    'time' => '16:00:00',
 		    'datetime' => '2020-02-19T16:00:00+00:00',
@@ -330,7 +340,15 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$meetings = $response->get_data();
 
 		$this->assertEquals( $this->_january_meetings(), $meetings );
+	}
 
+	public function test_meetings_february_2020() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-02-01' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$meetings = $response->get_data();
+
+		#$this->assertEquals( $this->_january_meetings(), $meetings );
 
 	}
 


### PR DESCRIPTION
Includes associated tests. Also fixed a bug in the "nth wednesday" calculations where a starting month was specified.

The new endpoint looks like `/wp/v2/meetings/from/2020-01-01`, and will return approximately 6 weeks of meetings starting on that date.