### PR TITLE
Update the event context and filter the events by a team.

### DIFF
--- a/src/frontend/calendar/grid.js
+++ b/src/frontend/calendar/grid.js
@@ -3,13 +3,12 @@
  */
 import CalendarCell from './cell';
 import CalendarHeader from './header';
-import { getRows, getSortedEvents } from './utils';
+import { getRows } from './utils';
 import { useEvents } from '../store/event-context';
 
 function CalendarGrid( { month, year } ) {
 	const rows = getRows( year, month );
-	const { events: unsortedEvents } = useEvents();
-	const events = getSortedEvents( unsortedEvents );
+	const { events } = useEvents();
 
 	return (
 		<table>

--- a/src/frontend/calendar/grid.js
+++ b/src/frontend/calendar/grid.js
@@ -8,7 +8,8 @@ import { useEvents } from '../store/event-context';
 
 function CalendarGrid( { month, year } ) {
 	const rows = getRows( year, month );
-	const events = getSortedEvents( useEvents() );
+	const { events: unsortedEvents } = useEvents();
+	const events = getSortedEvents( unsortedEvents );
 
 	return (
 		<table>

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -11,6 +11,7 @@ import { useState, Fragment } from '@wordpress/element';
  */
 import CalendarGrid from './grid';
 import List from '../list';
+import Filter from '../filter';
 import { useViews } from '../store/view-context';
 
 function Calendar() {
@@ -78,6 +79,7 @@ function Calendar() {
 					</Button>
 				</ButtonGroup>
 			</div>
+			<Filter />
 			{ isCalendarView() && (
 				<CalendarGrid month={ month } year={ year } />
 			) }

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -1,8 +1,3 @@
-/**
- * WordPress dependencies
- */
-import { format } from '@wordpress/date';
-
 // Default value for days not in this month.
 const emptyDate = {
 	blank: true,
@@ -45,22 +40,4 @@ export function getRows( year, month ) {
 	}
 
 	return rows;
-}
-
-/**
- * Get the list of events in day-buckets.
- *
- * @param {Array} events
- */
-export function getSortedEvents( events ) {
-	const sortedEvents = {};
-	events.forEach( ( event ) => {
-		const key = format( 'Y-m-d', event.date );
-		if ( sortedEvents.hasOwnProperty( key ) ) {
-			sortedEvents[ key ].push( event );
-		} else {
-			sortedEvents[ key ] = [ event ];
-		}
-	} );
-	return sortedEvents;
 }

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -10,15 +10,15 @@ import { Button } from '@wordpress/components';
 import { useEvents } from '../store/event-context';
 
 const Filter = () => {
-	const { team, clearTeam } = useEvents();
+	const { team, setTeam } = useEvents();
 
-	if( ! team.length ) {
+	if ( ! team.length ) {
 		return null;
 	}
 
 	return (
 		<div className="wporg-meeting-calendar__filter">
-			<Button isLink onClick={ () => void clearTeam() }>
+			<Button isLink onClick={ () => void setTeam( '' ) }>
 				{ __( 'Show meetings for other teams', 'wporg' ) }
 			</Button>
 		</div>

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useEvents } from '../store/event-context';
+
+const Filter = () => {
+	const { team, clearTeam } = useEvents();
+
+	if( ! team.length ) {
+		return null;
+	}
+
+	return (
+		<div className="wporg-meeting-calendar__filter">
+			<Button isLink onClick={ () => void clearTeam() }>
+				{ __( 'Show meetings for other teams', 'wporg' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default Filter;

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,28 +10,39 @@ import { Button } from '@wordpress/components';
 import { useEvents } from '../store/event-context';
 
 const Filter = () => {
-	const { team, setTeam } = useEvents();
-
-	if ( ! team.length ) {
-		return null;
-	}
+	const { events, teams, team, setTeam } = useEvents();
 
 	return (
 		<div className="wporg-meeting-calendar__filter">
-			<p>
-				Showing meetings for{ ' ' }
-				<span style={ { textTransform: 'capitalize' } }>
-					{ team } team.
-				</span>
-			</p>
-			<Button
-				icon="no-alt"
-				isLink
-				isDestructive
-				onClick={ () => void setTeam( '' ) }
-			>
-				{ __( 'Remove team filter', 'wporg' ) }
-			</Button>
+			<SelectControl
+				label={ __( 'Filter by team', 'wporg' ) }
+				value={ team }
+				options={ [
+					{ label: __( 'All teams', 'wporg' ), value: '' },
+					...teams,
+				] }
+				onChange={ ( value ) => {
+					setTeam( value );
+				} }
+			/>
+			{ '' !== team && (
+				<>
+					<p>
+						Showing meetings for{ ' ' }
+						<span style={ { textTransform: 'capitalize' } }>
+							{ team } team.
+						</span>
+					</p>
+					<Button
+						icon="no-alt"
+						isLink
+						isDestructive
+						onClick={ () => void setTeam( '' ) }
+					>
+						{ __( 'Remove team filter', 'wporg' ) }
+					</Button>
+				</>
+			) }
 		</div>
 	);
 };

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -18,8 +18,19 @@ const Filter = () => {
 
 	return (
 		<div className="wporg-meeting-calendar__filter">
-			<Button isLink onClick={ () => void setTeam( '' ) }>
-				{ __( 'Show meetings for other teams', 'wporg' ) }
+			<p>
+				Showing meetings for{ ' ' }
+				<span style={ { textTransform: 'capitalize' } }>
+					{ team } team.
+				</span>
+			</p>
+			<Button
+				icon="no-alt"
+				isLink
+				isDestructive
+				onClick={ () => void setTeam( '' ) }
+			>
+				{ __( 'Remove team filter', 'wporg' ) }
 			</Button>
 		</div>
 	);

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -10,7 +10,7 @@ import { Button, SelectControl } from '@wordpress/components';
 import { useEvents } from '../store/event-context';
 
 const Filter = () => {
-	const { events, teams, team, setTeam } = useEvents();
+	const { teams, team, setTeam } = useEvents();
 
 	return (
 		<div className="wporg-meeting-calendar__filter">

--- a/src/frontend/list/index.js
+++ b/src/frontend/list/index.js
@@ -13,7 +13,8 @@ import ListItem from './list-item';
 
 function List( { month, year } ) {
 	const rows = getRows( year, month );
-	const events = getSortedEvents( useEvents() );
+	const { events: unsortedEvents } = useEvents();
+	const events = getSortedEvents( unsortedEvents );
 	const allDays = rows.flat().filter( ( i ) => ! i.blank );
 
 	const days = allDays

--- a/src/frontend/list/index.js
+++ b/src/frontend/list/index.js
@@ -7,14 +7,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getRows, getSortedEvents } from '../calendar/utils';
+import { getRows } from '../calendar/utils';
 import { useEvents } from '../store/event-context';
 import ListItem from './list-item';
 
 function List( { month, year } ) {
 	const rows = getRows( year, month );
-	const { events: unsortedEvents } = useEvents();
-	const events = getSortedEvents( unsortedEvents );
+	const { events } = useEvents();
 	const allDays = rows.flat().filter( ( i ) => ! i.blank );
 
 	const days = allDays

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -3,7 +3,13 @@
  */
 import { format } from '@wordpress/date';
 
+/**
+ * Internal dependencies
+ */
+import { useEvents } from '../store/event-context';
+
 function ListItem( { date, events } ) {
+	const { setTeam } = useEvents();
 
 	return (
 		<li key={ `row-${ date }` }>
@@ -11,28 +17,29 @@ function ListItem( { date, events } ) {
 				<span>{ format( 'l - F j, Y', date ) }</span>
 			</strong>
 
-			{ events.map( ( e ) => {
+			{ events.map( ( event ) => {
 				return (
 					<article
 						className="wporg-meeting-calendar__list-event"
-						key={ e.instance_id }
+						key={ event.instance_id }
 					>
-						<div>{ format( 'g:i a: ', e.datetime ) }</div>
+						<div>{ format( 'g:i a: ', event.datetime ) }</div>
 						<div>
 							<a
 								className="wporg-meeting-calendar__list-event-team"
-								href={ `/${ e.team }` }
+								href={ `#${ event.team.toLowerCase() }` }
+								onClick={ ( clickEvent ) => {
+									clickEvent.preventDefault();
+									setTeam( event.team );
+								} }
 							>
-								{ e.team }
+								{ event.team }
 							</a>
-							<h3
-								className="wporg-meeting-calendar__list-event-title"
-								key={ e.id }
-							>
-								<a href={ e.link }>{ e.title }</a>
+							<h3 className="wporg-meeting-calendar__list-event-title">
+								<a href={ event.link }>{ event.title }</a>
 							</h3>
 							<span className="wporg-meeting-calendar__list-event-subtitle">
-								Location: { e.location }
+								Location: { event.location }
 							</span>
 						</div>
 					</article>

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createContext, useContext, useState } from '@wordpress/element';
+import { uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,9 +46,16 @@ export function EventsProvider( { children, value } ) {
 		);
 	}
 
+	// Get a list of all teams available.
+	const teams = uniqBy( value.map( ( e ) => ( {
+		label: e.team,
+		value: e.team.toLowerCase(),
+	} ) ), 'value' );
+
 	const initialState = {
 		events: getSortedEvents( eventsToDisplay ),
 		team,
+		teams,
 		setTeam: ( team ) => {
 			team = team.toLowerCase();
 			setTeam( team );

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -7,7 +7,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSortedEvents } from '../calendar/utils';
+import { getSortedEvents } from './utils';
 
 /**
  * Gets the team name if present in url.
@@ -20,6 +20,8 @@ function getTeamOnLoad() {
 
 /**
  * Add the team to the current URL, pushing to history for browser navigation support.
+ *
+ * @param {string} team
  */
 function setTeamEffect( team = '' ) {
 	if ( '' === team ) {
@@ -47,19 +49,22 @@ export function EventsProvider( { children, value } ) {
 	}
 
 	// Get a list of all teams available.
-	const teams = uniqBy( value.map( ( e ) => ( {
-		label: e.team,
-		value: e.team.toLowerCase(),
-	} ) ), 'value' );
+	const teams = uniqBy(
+		value.map( ( e ) => ( {
+			label: e.team,
+			value: e.team.toLowerCase(),
+		} ) ),
+		'value'
+	);
 
 	const initialState = {
 		events: getSortedEvents( eventsToDisplay ),
 		team,
 		teams,
-		setTeam: ( team ) => {
-			team = team.toLowerCase();
-			setTeam( team );
-			setTeamEffect( team );
+		setTeam: ( newTeam ) => {
+			newTeam = newTeam.toLowerCase();
+			setTeam( newTeam );
+			setTeamEffect( newTeam );
 		},
 	};
 

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -17,8 +17,15 @@ function getTeamOnLoad() {
 	return matches ? matches[ 0 ] : '';
 }
 
-function clearTeamFromUrl() {
-	window.history.pushState( '', document.title, window.location.pathname );
+/**
+ * Add the team to the current URL, pushing to history for browser navigation support.
+ */
+function setTeamEffect( team = '' ) {
+	if ( '' === team ) {
+		window.history.pushState( team, document.title, window.location.pathname );
+	} else {
+		window.history.pushState( team, document.title, '#' + team );
+	}
 }
 
 const StateContext = createContext();
@@ -37,10 +44,10 @@ export function EventsProvider( { children, value } ) {
 	const initialState = {
 		events: getSortedEvents( eventsToDisplay ),
 		team,
-		setTeam,
-		clearTeam() {
-			clearTeamFromUrl();
-			setTeam( '' );
+		setTeam: ( team ) => {
+			team = team.toLowerCase();
+			setTeam( team );
+			setTeamEffect( team );
 		},
 	};
 

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * WordPress dependencies
  */
 import { createContext, useContext, useState } from '@wordpress/element';
 
@@ -12,6 +12,10 @@ function getTeamOnLoad() {
 	const { location } = window;
 	const matches = location.href.match( /(?<=#).+/ );
 	return matches ? matches[ 0 ] : '';
+}
+
+function clearTeamFromUrl() {
+	window.history.pushState( '', document.title, window.location.pathname );
 }
 
 export function EventsProvider( { children, value } ) {
@@ -29,7 +33,10 @@ export function EventsProvider( { children, value } ) {
 		events: eventsToDisplay,
 		team,
 		setTeam,
-		clearTeam: () => setTeam( '' ),
+		clearTeam() {
+			clearTeamFromUrl();
+			setTeam( '' );
+		},
 	};
 
 	return (

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -3,7 +3,10 @@
  */
 import { createContext, useContext, useState } from '@wordpress/element';
 
-const StateContext = createContext();
+/**
+ * Internal dependencies
+ */
+import { getSortedEvents } from '../calendar/utils';
 
 /**
  * Gets the team name if present in url.
@@ -18,6 +21,8 @@ function clearTeamFromUrl() {
 	window.history.pushState( '', document.title, window.location.pathname );
 }
 
+const StateContext = createContext();
+
 export function EventsProvider( { children, value } ) {
 	const [ team, setTeam ] = useState( getTeamOnLoad() );
 
@@ -30,7 +35,7 @@ export function EventsProvider( { children, value } ) {
 	}
 
 	const initialState = {
-		events: eventsToDisplay,
+		events: getSortedEvents( eventsToDisplay ),
 		team,
 		setTeam,
 		clearTeam() {

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -21,7 +21,7 @@ export function EventsProvider( { children, value } ) {
 
 	if ( team && team.trim().length ) {
 		eventsToDisplay = value.filter(
-			( e ) => e.meta.team.toLowerCase() === team.toLowerCase()
+			( e ) => e.team.toLowerCase() === team.toLowerCase()
 		);
 	}
 

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -41,10 +41,8 @@ export function EventsProvider( { children, value } ) {
 
 export function useEvents() {
 	const context = useContext( StateContext );
-
 	if ( context === undefined ) {
 		throw new Error( 'useEvents must be used within a Provider' );
 	}
-
 	return context;
 }

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -22,7 +22,11 @@ function getTeamOnLoad() {
  */
 function setTeamEffect( team = '' ) {
 	if ( '' === team ) {
-		window.history.pushState( team, document.title, window.location.pathname );
+		window.history.pushState(
+			team,
+			document.title,
+			window.location.pathname
+		);
 	} else {
 		window.history.pushState( team, document.title, '#' + team );
 	}

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -1,13 +1,39 @@
 /**
  * External Dependencies
  */
-import { createContext, useContext } from '@wordpress/element';
+import { createContext, useContext, useState } from '@wordpress/element';
 
 const StateContext = createContext();
 
+/**
+ * Gets the team name if present in url.
+ */
+function getTeamOnLoad() {
+	const { location } = window;
+	const matches = location.href.match( /(?<=#).+/ );
+	return matches ? matches[ 0 ] : '';
+}
+
 export function EventsProvider( { children, value } ) {
+	const [ team, setTeam ] = useState( getTeamOnLoad() );
+
+	let eventsToDisplay = value;
+
+	if ( team && team.trim().length ) {
+		eventsToDisplay = value.filter(
+			( e ) => e.meta.team.toLowerCase() === team.toLowerCase()
+		);
+	}
+
+	const initialState = {
+		events: eventsToDisplay,
+		team,
+		setTeam,
+		clearTeam: () => setTeam( '' ),
+	};
+
 	return (
-		<StateContext.Provider value={ value }>
+		<StateContext.Provider value={ initialState }>
 			{ children }
 		</StateContext.Provider>
 	);
@@ -15,8 +41,10 @@ export function EventsProvider( { children, value } ) {
 
 export function useEvents() {
 	const context = useContext( StateContext );
+
 	if ( context === undefined ) {
 		throw new Error( 'useEvents must be used within a Provider' );
 	}
+
 	return context;
 }

--- a/src/frontend/store/utils.js
+++ b/src/frontend/store/utils.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { format } from '@wordpress/date';
+
+/**
+ * Get the list of events in day-buckets.
+ *
+ * @param {Array} events
+ */
+export function getSortedEvents( events ) {
+	const sortedEvents = {};
+	events.forEach( ( event ) => {
+		const key = format( 'Y-m-d', event.date );
+		if ( sortedEvents.hasOwnProperty( key ) ) {
+			sortedEvents[ key ].push( event );
+		} else {
+			sortedEvents[ key ] = [ event ];
+		}
+	} );
+	return sortedEvents;
+}

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -91,5 +91,10 @@
 }
 
 .wporg-meeting-calendar__filter {
+	display: flex;
 	margin-bottom: 12px;
+}
+
+.wporg-meeting-calendar__filter p {
+	flex: 1;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -92,9 +92,11 @@
 
 .wporg-meeting-calendar__filter {
 	display: flex;
+	align-items: center;
 	margin-bottom: 12px;
 }
 
 .wporg-meeting-calendar__filter p {
 	flex: 1;
+	margin: 0 1em;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -89,3 +89,7 @@
 .wporg-meeting-calendar__list-event-subtitle {
 	font-size: 0.75rem;
 }
+
+.wporg-meeting-calendar__filter {
+	margin-bottom: 12px;
+}


### PR DESCRIPTION
This PR:
- Adds functionality to the `event-context`
- Looks for `#{team}` loosely in the URL adds to state as `team`
- Filters events if `team` is set
- Adds a `setTeam` hook to support adding filtering
- Adds `<Filter>` component that clears the `team` when clicked showing all events.

Related Issue: https://github.com/Automattic/meeting-calendar/issues/24

![Screenshot](https://d.pr/i/gfD5DP.png)

