### PR TITLE
Take out the meta query

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -298,7 +298,6 @@ class Meeting_Post_Type {
 			'post_type' => 'meeting',
 			'post_status' => 'publish',
 			'numberposts' => -1,
-			'meta_query' => $this->meeting_meta_query(),
 		) );
 		$out = array();
 		foreach ( $meetings as $meeting ) {


### PR DESCRIPTION
This is causing the API function to sometimes (but not always) return empty results.

A better fix is needed, perhaps cleaning up the way date ranges are passed around within the class, but for now I'll take this out so it at least works.