### PR TITLE
Allow view of current and next month. Disable buttons otherwise.

### DIFF
--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -36,15 +36,10 @@ function Calendar() {
 				<div className="wporg-meeting-calendar__btn-group">
 					<Button
 						isSecondary
-						onClick={ () => void setDate( currentMonthYear ) }
-					>
-						{ __( 'Today', 'wporg' ) }
-					</Button>
-					<Button
-						isSecondary
 						onClick={ () =>
 							void setDate( { month: month - 1, year } )
 						}
+						disabled={ month === currentMonth }
 					>
 						{ __( 'Previous', 'wporg' ) }
 					</Button>
@@ -53,6 +48,7 @@ function Calendar() {
 						onClick={ () =>
 							void setDate( { month: month + 1, year } )
 						}
+						disabled={ month > currentMonth }
 					>
 						{ __( 'Next', 'wporg' ) }
 					</Button>


### PR DESCRIPTION
This PR:
- Disabled `Previous` if viewing this month
- Disabled `Next` if viewing next month
- Remove `Today` button.


Fixes Issue:https://github.com/Automattic/meeting-calendar/issues/40

**This Month:**
![Screenshot](https://d.pr/i/tvP67s.png)

**Next Month:**
![Screenshot](https://d.pr/i/ECtkcu.png)