### PR TITLE
Fix/single event bug

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -388,7 +388,7 @@ class Meeting_Post_Type {
 				$occurrences[] = $next;
 				$from = new DateTime( "{$next} {$meeting->time}" );
 			}
-		} while ( --$max > 0 && $next && $from && $from < $end );
+		} while ( --$max > 0 && $next && $from && $from < $end && $meeting->recurring );
 
 		return $occurrences;
 	}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -87,7 +87,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 
 			$dt = new DateTime( $future_date );
 			// It should be in the future
-			$this->assertGreaterThanOrEqual( new DateTime(), $dt );
+			$this->assertGreaterThanOrEqual( new DateTime( 'yesterday' ), $dt );
 			// Day of week should be Wednesday, same as the original
 			$this->assertEquals( 3, $dt->format( 'N' ) );
 

--- a/tests/test-meetingposttype.php
+++ b/tests/test-meetingposttype.php
@@ -1,0 +1,55 @@
+<?php
+use WordPressdotorg\Meeting_Calendar;
+/**
+ * Class MeetingPostTypeTest
+ *
+ * @package Meeting_Calendar
+ */
+
+/**
+ * Sample test case.
+ */
+class MeetingPostTypeTest extends WP_UnitTestCase {
+	protected $server;
+	protected $meeting_ids;
+	protected $mpt;
+
+	function setUp() {
+		parent::setUp();
+
+		// Install test data
+		$this->meeting_ids = Meeting_Calendar\wporg_meeting_install();
+
+		$this->mpt = Meeting_Post_Type::getInstance();
+	}
+
+	function test_single_meeting() {
+		// See https://github.com/Automattic/meeting-calendar/issues/34
+
+		$meeting_id = $this->factory->post->create( array(
+			'post_title' => __( 'A single meeting', 'wporg-meeting-calendar' ),
+			'post_type'  => 'meeting',
+			'post_status' => 'publish',
+			'meta_input' => array(
+				'team'       => 'Team-A',
+				'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+				'end_date'   => '',
+				'time'       => '01:00',
+				'recurring'  => '',
+				'link'       => 'wordpress.org',
+				'location'   => '#meta',
+				),
+		) );
+
+
+		$meetings = $this->mpt->get_occurrences_for_period(null);
+		$found = 0;
+		foreach ( $meetings as $meeting ) {
+			if ( $meeting['meeting_id'] === $meeting_id )
+				++ $found;
+		}
+
+		$this->assertEquals( 1, $found, 'There should be exactly one instance of a single meeting.' );
+	}
+
+}


### PR DESCRIPTION
This fixes a bug where single events would return multiple duplicate occurrences. Includes a unit test.

Fixes #34.