### PR TITLE
Try/event colors

### DIFF
--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -42,14 +42,15 @@ function CalendarCell( {
 						key={ event.instance_id }
 						isLink
 						onClick={ () => void onEventClick( event ) }
-						className={ `wporg-meeting-calendar__cellevent wporg-meeting-calendar__cellevent-${ getTeamClass(
-							event.team
-						) }` }
+						className={
+							'wporg-meeting-calendar__cell-event ' +
+							getTeamClass( event.team )
+						}
 					>
-						<div className="wporg-meeting-calendar__cellevent_time">
+						<div className="wporg-meeting-calendar__cell-event-time">
 							{ format( 'g:i a: ', event.datetime ) }
 						</div>
-						<div className="wporg-meeting-calendar__cellevent_title">
+						<div className="wporg-meeting-calendar__cell-event-title">
 							{ event.title }
 						</div>
 					</Button>
@@ -84,9 +85,13 @@ function CalendarCell( {
 								return (
 									<MenuItem
 										key={ event.instance_id }
-										isSecondary
+										isLink
 										onClick={ () =>
 											void onEventClick( event )
+										}
+										className={
+											'wporg-meeting-calendar__cell-event ' +
+											getTeamClass( event.team )
 										}
 									>
 										{ format( 'g:i a: ', event.datetime ) }

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -3,6 +3,11 @@
  */
 import { format } from '@wordpress/date';
 
+/**
+ * Internal dependencies
+ */
+import { getTeamClass } from './utils';
+
 function CalendarCell( { blank = false, year, month, day, events } ) {
 	if ( blank ) {
 		return <td aria-hidden />;
@@ -11,8 +16,6 @@ function CalendarCell( { blank = false, year, month, day, events } ) {
 	const date = new Date( year, month, day );
 	const key = format( 'Y-m-d', date );
 	const dayEvents = events[ key ] || [];
-
-	console.log( dayEvents );
 
 	return (
 		<td className="wporg-meeting-calendar__cell">
@@ -26,10 +29,9 @@ function CalendarCell( { blank = false, year, month, day, events } ) {
 				return (
 					<h3
 						key={ e.instance_id }
-						className={ [
-							'wporg-meeting-calendar__cellevent',
-							`wporg-meeting-calendar__cellevent-${ e.team.toLowerCase() }`,
-						].join( ' ' ) }
+						className={ `wporg-meeting-calendar__cellevent wporg-meeting-calendar__cellevent-${ getTeamClass(
+							e.team
+						) }` }
 					>
 						<span className="wporg-meeting-calendar__cellevent_time">
 							{ format( 'g:i a: ', e.datetime ) }

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -12,6 +12,8 @@ function CalendarCell( { blank = false, year, month, day, events } ) {
 	const key = format( 'Y-m-d', date );
 	const dayEvents = events[ key ] || [];
 
+	console.log( dayEvents );
+
 	return (
 		<td className="wporg-meeting-calendar__cell">
 			<strong>
@@ -22,9 +24,19 @@ function CalendarCell( { blank = false, year, month, day, events } ) {
 			</strong>
 			{ dayEvents.map( ( e ) => {
 				return (
-					<h3 key={ e.instance_id }>
-						{ format( 'g:i a: ', e.datetime ) }
-						{ e.title }
+					<h3
+						key={ e.instance_id }
+						className={ [
+							'wporg-meeting-calendar__cellevent',
+							`wporg-meeting-calendar__cellevent-${ e.team.toLowerCase() }`,
+						].join( ' ' ) }
+					>
+						<span className="wporg-meeting-calendar__cellevent_time">
+							{ format( 'g:i a: ', e.datetime ) }
+						</span>
+						<span className="wporg-meeting-calendar__cellevent_title">
+							{ e.title }
+						</span>
 					</h3>
 				);
 			} ) }

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -117,5 +117,8 @@ export function getSlackLink( location ) {
  * @param {string} team
  */
 export function getTeamClass( team ) {
-	return team.replace( ' ', '' ).toLowerCase();
+	return (
+		'wporg-meeting-calendar__team-' +
+		team.replace( [ ' ', '.' ], '-' ).toLowerCase()
+	);
 }

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -64,3 +64,12 @@ export function getSortedEvents( events ) {
 	} );
 	return sortedEvents;
 }
+
+/**
+ * Get a classname based on team name
+ *
+ * @param {string} team
+ */
+export function getTeamClass( team ) {
+	return team.replace( ' ', '' ).toLowerCase();
+}

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -3,8 +3,12 @@
  */
 import { format } from '@wordpress/date';
 
-function ListItem( { date, events } ) {
+/**
+ * Internal dependencies
+ */
+import { getTeamClass } from '../calendar/utils';
 
+function ListItem( { date, events } ) {
 	return (
 		<li key={ `row-${ date }` }>
 			<strong className="wporg-meeting-calendar__list-title">
@@ -17,10 +21,12 @@ function ListItem( { date, events } ) {
 						className="wporg-meeting-calendar__list-event"
 						key={ e.instance_id }
 					>
-						<div>{ format( 'g:i a: ', e.datetime ) }</div>
+						<div>{ format( 'g:i a ', e.datetime ) }</div>
 						<div>
 							<a
-								className="wporg-meeting-calendar__list-event-team"
+								className={ `wporg-meeting-calendar__list-event-team wporg-meeting-calendar__list-event-team-${ getTeamClass(
+									e.team
+								) }` }
 								href={ `/${ e.team }` }
 							>
 								{ e.team }

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -27,9 +27,10 @@ function ListItem( { date, events } ) {
 						<div>{ format( 'g:i a: ', event.datetime ) }</div>
 						<div>
 							<a
-								className={ `wporg-meeting-calendar__list-event-team wporg-meeting-calendar__list-event-team-${ getTeamClass(
-									event.team
-								) }` }
+								className={
+									'wporg-meeting-calendar__list-event-team ' +
+									getTeamClass( event.team )
+								}
 								href={ `#${ event.team.toLowerCase() }` }
 								onClick={ ( clickEvent ) => {
 									clickEvent.preventDefault();

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -55,10 +55,6 @@
 	overflow: hidden;
 }
 
-.wporg-meeting-calendar__cellevent-team-a {
-	background: #33b150;
-}
-
 .wporg-meeting-calendar__cellevent_title {
 	font-weight: bold;
 	display: block;
@@ -94,8 +90,24 @@
 	padding: 12px;
 }
 
+.wporg-meeting-calendar__list-event > div:first-child {
+	min-width: 125px;
+}
+
 .wporg-meeting-calendar__list-event-team {
-	font-size: 0.7rem;
+	font-size: 0.6rem;
+	padding: 2px 6px;
+	margin-bottom: 8px;
+	border-radius: 4px;
+	text-decoration: none !important;
+	background: DodgerBlue;
+	color: #fff;
+	display: inline-block;
+	font-family: sans-serif;
+}
+
+.wporg-meeting-calendar__list-event-team:hover {
+	color: #fff;
 }
 
 .wporg-meeting-calendar__list-event-title {
@@ -105,4 +117,94 @@
 
 .wporg-meeting-calendar__list-event-subtitle {
 	font-size: 0.75rem;
+}
+
+/** Colors for each team */
+.wporg-meeting-calendar__cellevent-core,
+.wporg-meeting-calendar__list-event-team-core {
+	background: #cd0000;
+}
+.wporg-meeting-calendar__cellevent-design,
+.wporg-meeting-calendar__list-event-team-design {
+	background: #eec26a;
+}
+.wporg-meeting-calendar__cellevent-mobile,
+.wporg-meeting-calendar__list-event-team-mobile {
+	background: #fba16c;
+}
+.wporg-meeting-calendar__cellevent-accessibility,
+.wporg-meeting-calendar__list-event-team-accessibility {
+	background: #11799d;
+}
+.wporg-meeting-calendar__cellevent-polyglots,
+.wporg-meeting-calendar__list-event-team-polyglots {
+	background: #c32283;
+}
+.wporg-meeting-calendar__cellevent-support,
+.wporg-meeting-calendar__list-event-team-support {
+	background: #33b4ce;
+}
+.wporg-meeting-calendar__cellevent-documentation,
+.wporg-meeting-calendar__list-event-team-documentation {
+	background: #3b7236;
+}
+.wporg-meeting-calendar__cellevent-themes,
+.wporg-meeting-calendar__list-event-team-themes {
+	background: #4e3288;
+}
+.wporg-meeting-calendar__cellevent-plugins,
+.wporg-meeting-calendar__list-event-team-plugins {
+	background: #f06723;
+}
+.wporg-meeting-calendar__cellevent-community,
+.wporg-meeting-calendar__list-event-team-community {
+	background: #11799d;
+}
+.wporg-meeting-calendar__cellevent-meetup_organizer,
+.wporg-meeting-calendar__list-event-team-meetup_organizer {
+	background: #f7ad43;
+}
+.wporg-meeting-calendar__cellevent-wordcamp_organizer,
+.wporg-meeting-calendar__list-event-team-wordcamp_organizer {
+	background: #f7ad43;
+}
+.wporg-meeting-calendar__cellevent-wordcamp_speaker,
+.wporg-meeting-calendar__list-event-team-wordcamp_speaker {
+	background: #f7ad43;
+}
+.wporg-meeting-calendar__cellevent-meta,
+.wporg-meeting-calendar__list-event-team-meta {
+	background: #aeadad;
+}
+.wporg-meeting-calendar__cellevent-training,
+.wporg-meeting-calendar__list-event-team-training {
+	background: #e9c02d;
+}
+.wporg-meeting-calendar__cellevent-wordpress.tv,
+.wporg-meeting-calendar__list-event-team-tv {
+	background: #73ad30;
+}
+.wporg-meeting-calendar__cellevent-marketing,
+.wporg-meeting-calendar__list-event-team-marketing {
+	background: #47bea7;
+}
+.wporg-meeting-calendar__cellevent-cli,
+.wporg-meeting-calendar__list-event-team-cli {
+	background: #424242;
+}
+.wporg-meeting-calendar__cellevent-hosting,
+.wporg-meeting-calendar__list-event-team-hosting {
+	background: #5358a6;
+}
+.wporg-meeting-calendar__cellevent-tide,
+.wporg-meeting-calendar__list-event-team-tide {
+	background: #1526ff;
+}
+.wporg-meeting-calendar__cellevent-bbpress,
+.wporg-meeting-calendar__list-event-team-bbpress {
+	background: #2d8e42;
+}
+.wporg-meeting-calendar__cellevent-buddypress,
+.wporg-meeting-calendar__list-event-team-buddypress {
+	background: #d84800;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -42,12 +42,13 @@
 	background: #ddd;
 }
 
-.wporg-meeting-calendar__cellevent.is-link {
+.wporg-meeting-calendar__cell-event.is-link {
 	display: block;
 	position: relative;
 	padding: 4px;
 	margin: 4px 0;
 	font-size: 12px;
+	font-weight: bold;
 	font-weight: normal;
 	background: #0085ba;
 	border-radius: 2px;
@@ -55,12 +56,25 @@
 	text-decoration: none;
 	width: 100%;
 }
+.wporg-meeting-calendar__cell-event.is-link.is-link:hover,
+.wporg-meeting-calendar__cell-event.is-link.is-link:active,
+.wporg-meeting-calendar__cell-event.is-link.is-link:focus {
+	color: #fff;
+}
+.wporg-meeting-calendar__cell-event.is-link.is-link:focus {
+	text-decoration: underline;
+	box-shadow: 0 0 0 1px black, 0 0 2px 1px rgba(0, 0, 0, 0.8);
+}
+.wporg-meeting-calendar__cell-event.components-menu-item__button {
+	white-space: nowrap;
+	overflow: hidden;
+}
 
-.wporg-meeting-calendar__cellevent_time {
+.wporg-meeting-calendar__cell-event-time {
 	font-weight: normal;
 }
 
-.wporg-meeting-calendar__cellevent_title {
+.wporg-meeting-calendar__cell-event-title {
 	font-weight: bold;
 	display: block;
 	white-space: nowrap;
@@ -107,19 +121,16 @@
 	margin-bottom: 8px;
 	border-radius: 4px;
 	text-decoration: none !important;
-	background: DodgerBlue;
+	background: #0085ba;
 	color: #fff !important;
 	display: inline-block;
 	font-family: sans-serif;
 }
+.wporg-meeting-calendar__list-event-team:hover,
+.wporg-meeting-calendar__list-event-team:active,
 .wporg-meeting-calendar__list-event-team:focus {
-	background: #fff;
-	color: #000 !important;
-	box-shadow: 0 0 0 1px #000;
-}
-
-.wporg-meeting-calendar__list-event-team:hover {
 	color: #fff;
+	text-decoration: underline !important;
 }
 
 .wporg-meeting-calendar__list-event-title {
@@ -132,92 +143,59 @@
 }
 
 /** Colors for each team */
-.wporg-meeting-calendar__cellevent-core,
-.wporg-meeting-calendar__list-event-team-core {
+.wporg-meeting-calendar__team-core {
 	background: #cd0000 !important;
 }
-.wporg-meeting-calendar__cellevent-design,
-.wporg-meeting-calendar__list-event-team-design {
+.wporg-meeting-calendar__team-design {
 	background: #eec26a !important;
 }
-.wporg-meeting-calendar__cellevent-mobile,
-.wporg-meeting-calendar__list-event-team-mobile {
+.wporg-meeting-calendar__team-mobile {
 	background: #fba16c !important;
 }
-.wporg-meeting-calendar__cellevent-accessibility,
-.wporg-meeting-calendar__list-event-team-accessibility {
-	background: #11799d !important;
-}
-.wporg-meeting-calendar__cellevent-polyglots,
-.wporg-meeting-calendar__list-event-team-polyglots {
+.wporg-meeting-calendar__team-polyglots {
 	background: #c32283 !important;
 }
-.wporg-meeting-calendar__cellevent-support,
-.wporg-meeting-calendar__list-event-team-support {
+.wporg-meeting-calendar__team-support {
 	background: #33b4ce !important;
 }
-.wporg-meeting-calendar__cellevent-documentation,
-.wporg-meeting-calendar__list-event-team-documentation {
+.wporg-meeting-calendar__team-documentation {
 	background: #3b7236 !important;
 }
-.wporg-meeting-calendar__cellevent-themes,
-.wporg-meeting-calendar__list-event-team-themes {
+.wporg-meeting-calendar__team-themes {
 	background: #4e3288 !important;
 }
-.wporg-meeting-calendar__cellevent-plugins,
-.wporg-meeting-calendar__list-event-team-plugins {
+.wporg-meeting-calendar__team-plugins {
 	background: #f06723 !important;
 }
-.wporg-meeting-calendar__cellevent-community,
-.wporg-meeting-calendar__list-event-team-community {
+.wporg-meeting-calendar__team-accessibility,
+.wporg-meeting-calendar__team-community {
 	background: #11799d !important;
 }
-.wporg-meeting-calendar__cellevent-meetup_organizer,
-.wporg-meeting-calendar__list-event-team-meetup_organizer {
-	background: #f7ad43 !important;
-}
-.wporg-meeting-calendar__cellevent-wordcamp_organizer,
-.wporg-meeting-calendar__list-event-team-wordcamp_organizer {
-	background: #f7ad43 !important;
-}
-.wporg-meeting-calendar__cellevent-wordcamp_speaker,
-.wporg-meeting-calendar__list-event-team-wordcamp_speaker {
-	background: #f7ad43 !important;
-}
-.wporg-meeting-calendar__cellevent-meta,
-.wporg-meeting-calendar__list-event-team-meta {
+.wporg-meeting-calendar__team-meta {
 	background: #aeadad !important;
 }
-.wporg-meeting-calendar__cellevent-training,
-.wporg-meeting-calendar__list-event-team-training {
+.wporg-meeting-calendar__team-training {
 	background: #e9c02d !important;
 }
-.wporg-meeting-calendar__cellevent-wordpress.tv,
-.wporg-meeting-calendar__list-event-team-tv {
+.wporg-meeting-calendar__team-tv {
 	background: #73ad30 !important;
 }
-.wporg-meeting-calendar__cellevent-marketing,
-.wporg-meeting-calendar__list-event-team-marketing {
+.wporg-meeting-calendar__team-marketing {
 	background: #47bea7 !important;
 }
-.wporg-meeting-calendar__cellevent-cli,
-.wporg-meeting-calendar__list-event-team-cli {
+.wporg-meeting-calendar__team-cli {
 	background: #424242 !important;
 }
-.wporg-meeting-calendar__cellevent-hosting,
-.wporg-meeting-calendar__list-event-team-hosting {
+.wporg-meeting-calendar__team-hosting {
 	background: #5358a6 !important;
 }
-.wporg-meeting-calendar__cellevent-tide,
-.wporg-meeting-calendar__list-event-team-tide {
+.wporg-meeting-calendar__team-tide {
 	background: #1526ff !important;
 }
-.wporg-meeting-calendar__cellevent-bbpress,
-.wporg-meeting-calendar__list-event-team-bbpress {
+.wporg-meeting-calendar__team-bbpress {
 	background: #2d8e42 !important;
 }
-.wporg-meeting-calendar__cellevent-buddypress,
-.wporg-meeting-calendar__list-event-team-buddypress {
+.wporg-meeting-calendar__team-buddypress {
 	background: #d84800 !important;
 }
 .wporg-meeting-calendar__filter {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -112,6 +112,11 @@
 	display: inline-block;
 	font-family: sans-serif;
 }
+.wporg-meeting-calendar__list-event-team:focus {
+	background: #fff;
+	color: #000 !important;
+	box-shadow: 0 0 0 1px #000;
+}
 
 .wporg-meeting-calendar__list-event-team:hover {
 	color: #fff;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -29,22 +29,39 @@
 }
 
 .wporg-meeting-calendar__cell {
-	padding: 12px;
+	padding: 4px;
 	vertical-align: top;
 	height: 5em; /* height acts as min-height on table cells */
 }
 
 .wporg-meeting-calendar__cell strong {
 	display: block;
-	margin: -12px -12px 0;
-	padding: 6px 12px;
+	margin: -4px -4px 0;
+	padding: 2px 4px;
 	font-size: 0.8em;
 	background: #ddd;
 }
 
-.wporg-meeting-calendar__cell h3 {
-	font-size: 0.8em;
+.wporg-meeting-calendar__cellevent {
+	position: relative;
+	padding: 4px;
+	margin: 4px 0;
+	font-size: 0.65rem;
 	font-weight: normal;
+	background: #0085ba;
+	border-radius: 2px;
+	color: #fff;
+	white-space: nowrap;
+	overflow: hidden;
+}
+
+.wporg-meeting-calendar__cellevent-team-a {
+	background: #33b150;
+}
+
+.wporg-meeting-calendar__cellevent_title {
+	font-weight: bold;
+	display: block;
 }
 
 .wporg-meeting-calendar__btn-group button {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -198,6 +198,19 @@
 .wporg-meeting-calendar__team-buddypress {
 	background: #d84800 !important;
 }
+.wporg-meeting-calendar__team-design,
+.wporg-meeting-calendar__team-mobile,
+.wporg-meeting-calendar__team-support,
+.wporg-meeting-calendar__team-plugins,
+.wporg-meeting-calendar__team-meta,
+.wporg-meeting-calendar__team-training,
+.wporg-meeting-calendar__team-tv,
+.wporg-meeting-calendar__team-marketing,
+.wporg-meeting-calendar__team-bbpress,
+.wporg-meeting-calendar__team-buddypress {
+	color: #000 !important;
+}
+
 .wporg-meeting-calendar__filter {
 	display: flex;
 	align-items: center;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -47,7 +47,7 @@
 	position: relative;
 	padding: 4px;
 	margin: 4px 0;
-	font-size: 0.5rem;
+	font-size: 12px;
 	font-weight: normal;
 	background: #0085ba;
 	border-radius: 2px;


### PR DESCRIPTION
Related to: https://github.com/Automattic/meeting-calendar/issues/32

This PR:
- Add color to teams in both views
- Colors teams are from here (https://make.wordpress.org/meta/handbook/documentation/profile-badges/)

**Screenshots:**

![List View](https://d.pr/i/UtbmJ7.png)


![Calendar](https://d.pr/i/UduYyx.png)