### PR TITLE
Add a grey block for the editor preview.

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -8,7 +8,12 @@ const EditView = ( { className } ) => {
 	return (
 		<div className={ className }>
 			<Icon icon="calendar" />
-			<h6>{ __( 'Meeting Calendar', 'wporg' ) }</h6>
+			<p>
+				{ __(
+					'Go to "Meetings" to add or edit your meetings',
+					'wporg'
+				) }
+			</p>
 		</div>
 	);
 };

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,5 +1,16 @@
-const EditView = () => {
-	return <div>The front end is alive.</div>;
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+
+const EditView = ( { className } ) => {
+	return (
+		<div className={ className }>
+			<Icon icon="calendar" />
+			<h6>{ __( 'Meeting Calendar', 'wporg' ) }</h6>
+		</div>
+	);
 };
 
 export default EditView;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+.wp-block-wporg-meeting-calendar-main {
+	padding: 32px;
+	text-align: center;
+	background: #ddd;
+}
+
+.wp-block-wporg-meeting-calendar-main > h6 {
+	margin: 0 !important;
+	font-size: 18px !important;
+	font-weight: normal;
+}

--- a/style.css
+++ b/style.css
@@ -4,8 +4,7 @@
 	background: #ddd;
 }
 
-.wp-block-wporg-meeting-calendar-main > h6 {
+.wp-block-wporg-meeting-calendar-main > p {
 	margin: 0 !important;
-	font-size: 18px !important;
-	font-weight: normal;
+	font-size: 16px !important;
 }


### PR DESCRIPTION
This PR:
- Adds a grey block to the block editor for previews.

![Block Preview](https://d.pr/i/AoPkCv.png)