### PR TITLE
Try `@wordpress/viewport` to handle small screen views

### DIFF
--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, ButtonGroup } from '@wordpress/components';
 import { date } from '@wordpress/date';
 import { useState, Fragment } from '@wordpress/element';
+import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import List from '../list';
 import Filter from '../filter';
 import { useViews } from '../store/view-context';
 
-function Calendar() {
+function Calendar( { shouldForceListView } ) {
 	const today = new Date();
 	const currentMonth = today.getMonth();
 	const currentYear = today.getFullYear();
@@ -29,6 +30,9 @@ function Calendar() {
 		setCalendarView,
 		setListView,
 	} = useViews();
+	if ( shouldForceListView && ! isListView() ) {
+		setListView();
+	}
 
 	return (
 		<Fragment>
@@ -63,6 +67,7 @@ function Calendar() {
 						isSecondary={ ! isCalendarView() }
 						isPrimary={ isCalendarView() }
 						onClick={ () => void setCalendarView() }
+						disabled={ shouldForceListView }
 					>
 						{ __( 'Month', 'wporg' ) }
 					</Button>
@@ -70,6 +75,7 @@ function Calendar() {
 						isSecondary={ ! isListView() }
 						isPrimary={ isListView() }
 						onClick={ () => void setListView() }
+						disabled={ shouldForceListView }
 					>
 						{ __( 'List', 'wporg' ) }
 					</Button>
@@ -84,4 +90,6 @@ function Calendar() {
 	);
 }
 
-export default Calendar;
+export default withViewportMatch( { shouldForceListView: '< medium' } )(
+	Calendar
+);

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -158,6 +158,16 @@
 	margin: 0 1em;
 }
 
+@media ( max-width: 782px ) {
+	.wporg-meeting-calendar__filter {
+		display: block;
+	}
+
+	.wporg-meeting-calendar__filter p {
+		margin: 1em 0 0.5em;
+	}
+}
+
 .wporg-meeting-calendar__modal h1 {
 	font-size: 16px !important;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -11,8 +11,8 @@
 
 .wporg-meeting-calendar__header {
 	display: flex;
-  align-items: center;
-  margin-bottom: 18px;
+	align-items: center;
+	margin-bottom: 18px;
 }
 
 .wporg-meeting-calendar__header div {
@@ -147,6 +147,67 @@
 	font-size: 16px;
 }
 
+.wporg-meeting-calendar__filter {
+	display: flex;
+	align-items: center;
+	margin-bottom: 12px;
+}
+
+.wporg-meeting-calendar__filter p {
+	flex: 1;
+	margin: 0 1em;
+}
+
+.wporg-meeting-calendar__modal h1 {
+	font-size: 16px !important;
+}
+.wporg-meeting-calendar__modal h1::before {
+	display: none !important;
+}
+
+.wporg-meeting-calendar__modal-overlay {
+	z-index: 1000001; /* popover z-index + 1 */
+}
+
+.wporg-meeting-calendar__filter {
+	display: flex;
+	align-items: center;
+	margin-bottom: 12px;
+	font-size: 16px;
+}
+
+.wporg-meeting-calendar__filter-label {
+	padding-right: 6px;
+	margin-bottom: 0;
+}
+
+.wporg-meeting-calendar__filter-applied {
+	flex: 1;
+	font-size: 16px;
+	margin: 0 1em;
+}
+
+/** Overwriting a default rule on the dropdown container */
+.wporg-meeting-calendar__filter-dropdown > div {
+	margin-bottom: 0 !important;
+}
+
+.wporg-meeting-calendar__modal h1 {
+	font-size: 16px !important;
+}
+
+.wporg-meeting-calendar__modal h1::before {
+	display: none !important;
+}
+
+.wporg-meeting-calendar__modal-overlay {
+	z-index: 1000001; /* popover z-index + 1 */
+}
+
+/* ========================================= */
+/* = @todo Move these styles to wporg CSS. = */
+/* ========================================= */
+
 /** Colors for each team */
 .wporg-meeting-calendar__team-core {
 	background: #cd0000 !important;
@@ -214,39 +275,4 @@
 .wporg-meeting-calendar__team-bbpress,
 .wporg-meeting-calendar__team-buddypress {
 	color: #000 !important;
-}
-
-.wporg-meeting-calendar__filter {
-	display: flex;
-	align-items: center;
-	margin-bottom: 12px;
-	font-size: 16px;
-}
-
-.wporg-meeting-calendar__filter-label {
-	padding-right: 6px;
-	margin-bottom: 0;
-}
-
-.wporg-meeting-calendar__filter-applied {
-	flex: 1;
-	font-size: 16px;
-	margin: 0 1em;
-}
-
-/** Overwriting a default rule on the dropdown container */
-.wporg-meeting-calendar__filter-dropdown > div {
-	margin-bottom: 0 !important;
-}
-
-.wporg-meeting-calendar__modal h1 {
-	font-size: 16px !important;
-}
-
-.wporg-meeting-calendar__modal h1::before {
-	display: none !important;
-}
-
-.wporg-meeting-calendar__modal-overlay {
-	z-index: 1000001; /* popover z-index + 1 */
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -98,6 +98,10 @@
 	list-style: none;
 }
 
+.wporg-meeting-calendar__list li {
+	margin-left: 0;
+}
+
 .wporg-meeting-calendar__list-title {
 	padding: 6px 12px;
 	display: block;


### PR DESCRIPTION
This is an alternate approach to #44 — using `withViewportMatch` from [`@wordpress/viewport`](https://github.com/WordPress/gutenberg/tree/master/packages/viewport) to force the list view on screens less than "medium" width, 782px.

This disables the view toggle for <782px, restricting the view to just List. If the screen is made wider, the toggle becomes active, but we don't switch the layout back automatically.

![Screen Shot 2020-03-05 at 11 00 37 AM](https://user-images.githubusercontent.com/541093/76000183-56767100-5ed1-11ea-996e-8f9cff8aac08.png)

Fixes #41