### PR TITLE
Fix/improve date range

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -380,14 +380,15 @@ class Meeting_Post_Type {
 		}
 
 		$from = DateTime::createFromFormat( 'U', strtotime( '-30 minutes', $now ) );
-		$end  = DateTime::createFromFormat( 'U', strtotime( '+1 month', $now ) );
+		$end  = DateTime::createFromFormat( 'U', strtotime( '+2 month', $now ) );
 		$max  = 12;
 		$occurrences = array();
 		do {
 			$next = $this->get_next_occurrence( $meeting, $from->format( 'Y-m-d H:i:s P' ) );
 			if ( $next ) {
-				$occurrences[] = $next;
 				$from = new DateTime( "{$next} {$meeting->time}" );
+				if ( $from <= $end )
+					$occurrences[] = $next;
 			}
 		} while ( --$max > 0 && $next && $from && $from < $end && $meeting->recurring );
 

--- a/plugin.php
+++ b/plugin.php
@@ -18,7 +18,7 @@ namespace WordPressdotorg\Meeting_Calendar;
  * @return string List of meetings in JSON format
  */
 function get_meeting_data( $per_page ) {
-	$date = date( 'Y-m-d', strtotime( '-1 week' ) );
+	$date = date( 'Y-m-d', strtotime( 'first day of this month' ) );
 	$request = new \WP_REST_Request( 'GET', '/wp/v2/meetings/from/' . $date );
 	$request->set_query_params( [ 'per_page' => $per_page ] );
 	$response = rest_do_request( $request );


### PR DESCRIPTION
This defaults to fetching events from the beginning of the current month, and includes 2 months worth of data.