### PR TITLE
Accessibility cleanup + improvements

### DIFF
--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -32,7 +32,17 @@ function CalendarCell( {
 		<td className="wporg-meeting-calendar__cell">
 			<strong>
 				<span className="screen-reader-text">
-					{ format( 'F j', date ) }
+					{ format( 'F j', date ) }{ ' ' }
+					{ // translators: %d: Count of all events, ie: 4.
+					sprintf(
+						_n(
+							'%d event',
+							'%d events',
+							dayEvents.length,
+							'wporg'
+						),
+						dayEvents.length
+					) }
 				</span>
 				<span aria-hidden>{ day }</span>
 			</strong>

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { date } from '@wordpress/date';
-import { useState, Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -68,14 +69,26 @@ function Calendar() {
 					<Button
 						isSecondary={ ! isCalendarView() }
 						isPrimary={ isCalendarView() }
-						onClick={ () => void setCalendarView() }
+						onClick={ () => {
+							if ( ! isCalendarView() ) {
+								speak(
+									__( 'Switched to calendar view', 'wporg' )
+								);
+							}
+							setCalendarView();
+						} }
 					>
 						{ __( 'Month', 'wporg' ) }
 					</Button>
 					<Button
 						isSecondary={ ! isListView() }
 						isPrimary={ isListView() }
-						onClick={ () => void setListView() }
+						onClick={ () => {
+							if ( ! isListView() ) {
+								speak( __( 'Switched to list view', 'wporg' ) );
+							}
+							setListView();
+						} }
 					>
 						{ __( 'List', 'wporg' ) }
 					</Button>

--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, ButtonGroup } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { date } from '@wordpress/date';
 import { useState, Fragment } from '@wordpress/element';
 
@@ -33,7 +33,10 @@ function Calendar() {
 	return (
 		<Fragment>
 			<div className="wporg-meeting-calendar__header">
-				<div className="wporg-meeting-calendar__btn-group">
+				<nav
+					className="wporg-meeting-calendar__btn-group"
+					aria-label={ __( 'Month navigation', 'wporg' ) }
+				>
 					<Button
 						isSecondary
 						onClick={ () =>
@@ -52,13 +55,16 @@ function Calendar() {
 					>
 						{ __( 'Next', 'wporg' ) }
 					</Button>
-				</div>
+				</nav>
 				<div>
 					<h2 aria-live="polite" aria-atomic>
 						{ date( 'F Y', new Date( year, month, 1 ) ) }
 					</h2>
 				</div>
-				<ButtonGroup>
+				<nav
+					className="components-button-group"
+					aria-label={ __( 'View options', 'wporg' ) }
+				>
 					<Button
 						isSecondary={ ! isCalendarView() }
 						isPrimary={ isCalendarView() }
@@ -73,7 +79,7 @@ function Calendar() {
 					>
 						{ __( 'List', 'wporg' ) }
 					</Button>
-				</ButtonGroup>
+				</nav>
 			</div>
 			<Filter />
 			{ isCalendarView() && (

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, SelectControl } from '@wordpress/components';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -24,14 +25,23 @@ const Filter = () => {
 			</label>
 			<SelectControl
 				id={ dropdownId }
-				value={ team }
 				className="wporg-meeting-calendar__filter-dropdown"
+				value={ team }
 				options={ [
 					{ label: __( 'All teams', 'wporg' ), value: '' },
 					...teams,
 				] }
 				onChange={ ( value ) => {
 					setTeam( value );
+					const newSelected = teams.find(
+						( option ) => value === option.value
+					);
+					speak(
+						sprintf(
+							__( 'Showing meetings for %s', 'wporg' ),
+							newSelected.label
+						)
+					);
 				} }
 			/>
 			{ '' !== team && (

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, SelectControl } from '@wordpress/components';
 import { speak } from '@wordpress/a11y';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import { speak } from '@wordpress/a11y';
 import { useEvents } from '../store/event-context';
 
 const Filter = () => {
+	const filterLabel = useRef( null );
 	const { teams, team, setTeam } = useEvents();
 	const dropdownId = 'wporg-meeting-calendar__filter-dropdown';
 	const selected = teams.find( ( option ) => team === option.value );
@@ -20,6 +22,7 @@ const Filter = () => {
 			<label
 				className="wporg-meeting-calendar__filter-label"
 				htmlFor={ dropdownId }
+				ref={ filterLabel }
 			>
 				{ __( 'Filter by team: ', 'wporg' ) }
 			</label>
@@ -56,7 +59,11 @@ const Filter = () => {
 						icon="no-alt"
 						isLink
 						isDestructive
-						onClick={ () => void setTeam( '' ) }
+						onClick={ () => {
+							setTeam( '' );
+							speak( __( 'Showing all meetings.', 'wporg' ) );
+							filterLabel.current.focus();
+						} }
 					>
 						{ __( 'Remove team filter', 'wporg' ) }
 					</Button>

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button, SelectControl } from '@wordpress/components';
 
 /**
@@ -12,6 +12,7 @@ import { useEvents } from '../store/event-context';
 const Filter = () => {
 	const { teams, team, setTeam } = useEvents();
 	const dropdownId = 'wporg-meeting-calendar__filter-dropdown';
+	const selected = teams.find( ( option ) => team === option.value );
 
 	return (
 		<div className="wporg-meeting-calendar__filter">
@@ -36,10 +37,10 @@ const Filter = () => {
 			{ '' !== team && (
 				<>
 					<p className="wporg-meeting-calendar__filter-applied">
-						Showing meetings for{ ' ' }
-						<span style={ { textTransform: 'capitalize' } }>
-							{ team } team.
-						</span>
+						{ sprintf(
+							__( 'Showing meetings for %s', 'wporg' ),
+							selected.label
+						) }
 					</p>
 					<Button
 						icon="no-alt"

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -43,7 +43,8 @@ const Filter = () => {
 						sprintf(
 							__( 'Showing meetings for %s', 'wporg' ),
 							newSelected.label
-						)
+						),
+						'assertive'
 					);
 				} }
 			/>
@@ -61,7 +62,10 @@ const Filter = () => {
 						isDestructive
 						onClick={ () => {
 							setTeam( '' );
-							speak( __( 'Showing all meetings.', 'wporg' ) );
+							speak(
+								__( 'Showing all meetings.', 'wporg' ),
+								'assertive'
+							);
 							filterLabel.current.focus();
 						} }
 					>

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { format } from '@wordpress/date';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -24,6 +25,16 @@ function ListItem( { date, events } ) {
 			</strong>
 
 			{ events.map( ( event ) => {
+				const onTeamClick = ( clickEvent ) => {
+					clickEvent.preventDefault();
+					setTeam( event.team );
+					speak(
+						sprintf(
+							__( 'Showing meetings for %s', 'wporg' ),
+							event.team
+						)
+					);
+				};
 				return (
 					<article
 						className="wporg-meeting-calendar__list-event"
@@ -36,11 +47,12 @@ function ListItem( { date, events } ) {
 									'wporg-meeting-calendar__list-event-team ' +
 									getTeamClass( event.team )
 								}
+								aria-label={ sprintf(
+									__( 'All %s meetings', 'wporg' ),
+									event.team
+								) }
 								href={ `#${ event.team.toLowerCase() }` }
-								onClick={ ( clickEvent ) => {
-									clickEvent.preventDefault();
-									setTeam( event.team );
-								} }
+								onClick={ onTeamClick }
 							>
 								{ event.team }
 							</a>

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -273,6 +273,7 @@
 .wporg-meeting-calendar__team-support {
 	background: #33b4ce !important;
 }
+.wporg-meeting-calendar__team-docs,
 .wporg-meeting-calendar__team-documentation {
 	background: #3b7236 !important;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -45,7 +45,7 @@
 	background: #ddd;
 }
 
-.wporg-meeting-calendar__cell-event.is-link {
+.wporg-meeting-calendar__cell-event.components-button {
 	display: block;
 	position: relative;
 	padding: 4px;
@@ -53,22 +53,24 @@
 	font-size: 12px;
 	font-weight: bold;
 	font-weight: normal;
-	background: #0085ba;
 	border-radius: 2px;
-	color: #fff;
-	text-decoration: none;
 	width: 100%;
 }
-.wporg-meeting-calendar__cell-event.is-link.is-link:hover,
-.wporg-meeting-calendar__cell-event.is-link.is-link:active,
-.wporg-meeting-calendar__cell-event.is-link.is-link:focus {
-	color: #fff;
+/* These styles are separate for !important specificity with `wporg-meeting-calendar__team-*` styles below. */
+.wporg-meeting-calendar__cell-event {
+	background: #0085ba !important;
+	color: #fff !important;
+	text-decoration: none !important;
 }
-.wporg-meeting-calendar__cell-event.is-link.is-link:focus {
-	text-decoration: underline;
-	box-shadow: 0 0 0 1px black, 0 0 2px 1px rgba(0, 0, 0, 0.8);
+.wporg-meeting-calendar__cell-event:focus {
+	text-decoration: underline !important;
+	box-shadow: 0 0 0 1px black, 0 0 2px 1px rgba(0, 0, 0, 0.8) !important;
 }
-.wporg-meeting-calendar__cell-event.components-menu-item__button {
+
+.wporg-meeting-calendar__dropdown .components-menu-group {
+	padding: 7px;
+}
+.wporg-meeting-calendar__dropdown .components-menu-item__button {
 	white-space: nowrap;
 	overflow: hidden;
 }


### PR DESCRIPTION
This PR cleans up/improves the interactions for screen reader users (mostly) & keyboard-only users.

- Switched the button containers to `nav`, which gives the buttons more context that's missing when you can't see the screen.
- Add the number of events on each day to each cell, so days can be skipped and it's clear when days have no events (it's not just a glitch).
- The filter announces when selected teams change the view, and removing the filter moves the focus back to the select input.

**To test**

Try moving through the calendar with just your keyboard, or by using a screen reader.