### PR TITLE
Fix/cancel in shortcode

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -710,7 +710,10 @@ class Meeting_Post_Type {
 			add_action( 'wp_footer', array( $this, 'time_conversion_script' ), 999 );
 		}
 
-		switch_to_blog( get_main_site_id() );
+		// If we're on a network, assume the calendar exists on the main site
+		if ( function_exists( 'switch_to_blog' ) ) {
+			switch_to_blog( get_main_site_id() );
+		}
 
 		$query = new WP_Query(
 			array(
@@ -759,7 +762,9 @@ class Meeting_Post_Type {
 			$out .= '</p>';
 		}
 
-		restore_current_blog();
+		if ( function_exists( 'restore_current_blog' ) ) {
+			restore_current_blog();
+		}
 
 		return $out;
 	}

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -746,18 +746,25 @@ class Meeting_Post_Type {
 				$slack_channel = sanitize_title( $match[1] );
 			}
 
-			$out .= '<p>';
+			$cancelled = $this->is_meeting_cancelled( $post->ID, $post->next_date );
+
+			$out .= '<p class="wporg-meeting-shortcode' . ( $cancelled ? ' meeting-cancelled' : '') . '">';
+
 			$out .= esc_html( $attr['before'] );
 			$out .= '<strong class="meeting-title">' . esc_html( $post->post_title ) . '</strong>';
 			$display_more = $query->found_posts - intval( $limit );
 			if ( $display_more > 0 ) {
 				$out .= ' <a title="Click to view all meetings for this team" href="/meetings/#' . esc_attr( strtolower( $attr['team'] ) ) . '">' . sprintf( __( '(+%s more)'), $display_more ) . '</a>';
 			}
-			$out .= '</br>';
+			$out .= '<br/>';
 			$out .= '<time class="date" date-time="' . esc_attr( $next_meeting_iso ) . '" title="' . esc_attr( $next_meeting_iso ) . '">' . $next_meeting_display . '</time> ';
 			$out .= sprintf( esc_html__( '(%s from now)' ), human_time_diff( $next_meeting_timestamp, current_time('timestamp') ) );
 			if ( $post->location && $slack_channel ) {
 				$out .= ' ' . sprintf( wp_kses( __('at <a href="%s">%s</a> on Slack'), array(  'a' => array( 'href' => array() ) ) ), 'https://wordpress.slack.com/messages/' . $slack_channel,   $post->location );
+			}
+			if ( $cancelled ) {
+				$out .= '<br>';
+				$out .= '<i>' . __( 'This event is cancelled.') . '</i>';
 			}
 			$out .= '</p>';
 		}

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -749,6 +749,7 @@ class Meeting_Post_Type {
 			$cancelled = $this->is_meeting_cancelled( $post->ID, $post->next_date );
 
 			$out .= '<p class="wporg-meeting-shortcode' . ( $cancelled ? ' meeting-cancelled' : '') . '">';
+			$out .= '<span class="wporg-meeting-detail">';
 
 			$out .= esc_html( $attr['before'] );
 			$out .= '<strong class="meeting-title">' . esc_html( $post->post_title ) . '</strong>';
@@ -762,9 +763,22 @@ class Meeting_Post_Type {
 			if ( $post->location && $slack_channel ) {
 				$out .= ' ' . sprintf( wp_kses( __('at <a href="%s">%s</a> on Slack'), array(  'a' => array( 'href' => array() ) ) ), 'https://wordpress.slack.com/messages/' . $slack_channel,   $post->location );
 			}
+			$out .= '</span>';
+
 			if ( $cancelled ) {
 				$out .= '<br>';
-				$out .= '<i>' . __( 'This event is cancelled.') . '</i>';
+				$future_occurrences = $this->get_future_occurrences( $post, null, array() );
+				$next_meeting = null;
+				foreach ( $future_occurrences as $occurrence ) {
+					if ( !$this->is_meeting_cancelled( $post->ID, $occurrence )
+							&& $occurrence > $post->next_date )
+						$next_meeting = $occurrence;
+				}
+				if ( $next_meeting ) {
+					$out .= '<i>' . sprintf( esc_html__( 'This event is cancelled. The next meeting is scheduled for %s.', 'wporg' ), $next_meeting ) . '</i>';
+				} else {
+					$out .= '<i>' . esc_html__( 'This event is cancelled.', 'wporg' ) . '</i>';
+				}
 			}
 			$out .= '</p>';
 		}

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -250,3 +250,8 @@
 .wporg-meeting-calendar__modal-overlay {
 	z-index: 1000001; /* popover z-index + 1 */
 }
+
+.wporg-meeting-shortcode.meeting-cancelled {
+	text-decoration: line-through;
+}
+

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -251,7 +251,7 @@
 	z-index: 1000001; /* popover z-index + 1 */
 }
 
-.wporg-meeting-shortcode.meeting-cancelled {
+.meeting-cancelled .wporg-meeting-detail {
 	text-decoration: line-through;
 }
 

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -1,0 +1,94 @@
+<?php
+use WordPressdotorg\Meeting_Calendar;
+/**
+ * Class MeetingShortcodeTest
+ *
+ * @package Meeting_Calendar
+ */
+
+/**
+ * Sample test case.
+ */
+class MeetingShortcodeTest extends WP_UnitTestCase {
+	protected $server;
+	protected $meeting_ids;
+	protected $mpt;
+
+	function setUp() {
+		parent::setUp();
+
+		// Install test data
+		$this->meeting_ids = Meeting_Calendar\wporg_meeting_install();
+
+		$this->mpt = Meeting_Post_Type::getInstance();
+	}
+
+	function test_shortcode_simple() {
+
+		// A one-off meeting tomorrow
+		$meeting_1 = $this->factory->post->create( array(
+			'post_title' => __( 'Meeting One', 'wporg-meeting-calendar' ),
+			'post_type'  => 'meeting',
+			'post_status' => 'publish',
+			'meta_input' => array(
+				'team'       => 'Team-F',
+				'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+				'end_date'   => '',
+				'time'       => '01:00',
+				'recurring'  => '',
+				'link'       => 'wordpress.org',
+				'location'   => '#meta',
+				),
+		) );
+
+		// A recurring weekly meeting, starting yesterday
+		$meeting_1 = $this->factory->post->create( array(
+			'post_title' => __( 'Meeting Two', 'wporg-meeting-calendar' ),
+			'post_type'  => 'meeting',
+			'post_status' => 'publish',
+			'meta_input' => array(
+				'team'       => 'Team-F',
+				'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
+				'end_date'   => '',
+				'time'       => '02:00',
+				'recurring'  => 'weekly',
+				'link'       => 'wordpress.org',
+				'location'   => '#meta',
+				),
+		) );
+
+		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
+
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong></br><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) )) );
+
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting Two</strong></br><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) )) );
+	}
+
+	function test_shortcode_cancelled() {
+
+		// A recurring weekly meeting, starting yesterday
+		$meeting_1 = $this->factory->post->create( array(
+			'post_title' => __( 'Meeting One', 'wporg-meeting-calendar' ),
+			'post_type'  => 'meeting',
+			'post_status' => 'publish',
+			'meta_input' => array(
+				'team'       => 'Team-F',
+				'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
+				'end_date'   => '',
+				'time'       => '01:00',
+				'recurring'  => 'weekly',
+				'link'       => 'wordpress.org',
+				'location'   => '#meta',
+				),
+		) );
+
+		// Cancel the meeting that's in 6 days
+		$this->mpt->cancel_meeting( array( 'meeting_id' => $meeting_1, 'date' => strftime( '%Y-%m-%d', strtotime( 'yesterday + 6 days' ) ) ) );
+
+		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
+
+
+		// The shortcode should show the next meeting is in 13 days
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong></br><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +14 days' ) )) );
+	}
+}


### PR DESCRIPTION
Work in progress: `test_shortcode_cancelled()` currently fails. We need to decide how to display cancelled meetings (omit? strikethrough?) - see #66 