### PR TITLE
Add some styles to indicate the cell is 'today'

### DIFF
--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -8,7 +8,7 @@ import { format } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import { getTeamClass } from './utils';
+import { getTeamClass, isToday } from './utils';
 
 function CalendarCell( {
 	blank = false,
@@ -29,7 +29,11 @@ function CalendarCell( {
 	const restOfEvents = dayEvents.slice( MAX_EVENTS );
 
 	return (
-		<td className="wporg-meeting-calendar__cell">
+		<td
+			className={ `wporg-meeting-calendar__cell ${
+				isToday( date ) ? 'today' : ''
+			}` }
+		>
 			<strong>
 				<span className="screen-reader-text">
 					{ format( 'F j', date ) }{ ' ' }

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -31,7 +31,7 @@ function CalendarCell( {
 	return (
 		<td
 			className={ `wporg-meeting-calendar__cell ${
-				isToday( date ) ? 'today' : ''
+				isToday( date ) ? 'is-today' : ''
 			}` }
 		>
 			<strong>

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -122,3 +122,17 @@ export function getTeamClass( team ) {
 		team.replace( [ ' ', '.' ], '-' ).toLowerCase()
 	);
 }
+
+/**
+ * Checks whether a date is today
+ *
+ * @param {date} date
+ */
+export function isToday( date ) {
+	const today = new Date();
+	return (
+		date.getDate() == today.getDate() &&
+		date.getMonth() == today.getMonth() &&
+		date.getFullYear() == today.getFullYear()
+	);
+}

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -126,7 +126,7 @@ export function getTeamClass( team ) {
 /**
  * Checks whether a date is today
  *
- * @param {date} date
+ * @param {Object} date
  */
 export function isToday( date ) {
 	const today = new Date();

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -37,6 +37,10 @@
 	height: 180px; /* height acts as min-height on table cells */
 }
 
+.wporg-meeting-calendar__cell.today {
+	background: #fcf8e3;
+}
+
 .wporg-meeting-calendar__cell strong {
 	display: block;
 	margin: -4px -4px 0;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -37,7 +37,7 @@
 	height: 180px; /* height acts as min-height on table cells */
 }
 
-.wporg-meeting-calendar__cell.today {
+.wporg-meeting-calendar__cell.is-today {
 	background: #fcf8e3;
 }
 


### PR DESCRIPTION
This self serving :) PR:
- Adds styles for today to help contextualize the calendar.

Note: The styles appear muted but will be more apparent if we merge https://github.com/Automattic/meeting-calendar/pull/62

**Screenshot**
![s](https://d.pr/i/x4vPqP.png)