### PR TITLE
Filter: Remove when there are less than 2 teams

### DIFF
--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -12,8 +12,12 @@ import { useRef } from '@wordpress/element';
 import { useEvents } from '../store/event-context';
 
 const Filter = () => {
-	const filterLabel = useRef( null );
 	const { teams, team, setTeam } = useEvents();
+	if ( teams.length < 2 ) {
+		return null;
+	}
+
+	const filterLabel = useRef( null );
 	const dropdownId = 'wporg-meeting-calendar__filter-dropdown';
 	const selected = teams.find( ( option ) => team === option.value );
 


### PR DESCRIPTION
If there are no teams, or only 1 team, the filter does nothing. This removes it from the rendered app.

![Screen Shot 2020-03-10 at 1 06 47 PM](https://user-images.githubusercontent.com/541093/76339088-03852b00-62d0-11ea-9a7c-191e4e19dea3.png)
