### PR TITLE
Add in microdata to list view.

### DIFF
--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -39,8 +39,12 @@ function ListItem( { date, events } ) {
 					<article
 						className="wporg-meeting-calendar__list-event"
 						key={ event.instance_id }
+						itemScope
+						itemType="http://schema.org/Event"
 					>
-						<div>{ format( 'g:i a: ', event.datetime ) }</div>
+						<div itemProp="startDate" content={ event.datetime }>
+							{ format( 'g:i a ', event.datetime ) }
+						</div>
 						<div className="wporg-meeting-calendar__list-event-details">
 							{ event.team && (
 								<a
@@ -54,13 +58,20 @@ function ListItem( { date, events } ) {
 									) }
 									href={ `#${ event.team.toLowerCase() }` }
 									onClick={ onTeamClick }
+									itemType="http://schema.org/Organization"
+									itemScope
 								>
-									{ event.team }
+									<span itemProp="name">{ event.team }</span>
 								</a>
 							) }
 							<div>
-								<h3 className="wporg-meeting-calendar__list-event-title">
-									<a href={ event.link }>{ event.title }</a>
+								<h3
+									className="wporg-meeting-calendar__list-event-title"
+									itemProp="name"
+								>
+									<a itemProp="url" href={ event.link }>
+										{ event.title }
+									</a>
 								</h3>
 								<p className="wporg-meeting-calendar__list-event-copy">
 									{ __( 'Meets: ', 'wporg' ) }


### PR DESCRIPTION
This experimental PR:
- Adds `microdata` to the list view

This is an experiment more than a necessary feature. 

This could be valueless because Google appears to only favor events with physical locations. We therefore are forced to provide invalid microdata. There seems to debate as to whether online events should be marked up with microdata. 

*Note: Since our plugin will be open source, others may use it for physical events.

**The Rub**
- If we provide `location` we need to provide an `address`.
- If we omit `location` we get a validation error.

Just wondering what others think?