### PR TITLE
Fix unit test failures

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -772,8 +772,10 @@ class Meeting_Post_Type {
 				$next_meeting = null;
 				foreach ( $future_occurrences as $occurrence ) {
 					if ( !$this->is_meeting_cancelled( $post->ID, $occurrence )
-							&& $occurrence > $post->next_date )
+							&& $occurrence > $post->next_date ) {
 						$next_meeting = $occurrence;
+						break;
+					}
 				}
 				if ( $next_meeting ) {
 					$out .= '<i>' . sprintf( esc_html__( 'This event is cancelled. The next meeting is scheduled for %s.', 'wporg' ), $next_meeting ) . '</i>';

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -333,6 +333,36 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  ),
 		  9 => 
 		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-02-12',
+		    'date' => '2020-02-12',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-02-12T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'location' => '#meta',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  10 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-02-19',
+		    'date' => '2020-02-19',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-02-19T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'location' => '#meta',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
+		    'status' => 'active',
+		  ),
+		  11 => 
+		  array (
 		    'meeting_id' => $this->meeting_ids[2],
 		    'instance_id' => $this->meeting_ids[2] . ':2020-02-19',
 		    'date' => '2020-02-19',
@@ -347,6 +377,21 @@ class MeetingAPITest extends WP_UnitTestCase {
 		    array (
 		      0 => 3,
 		    ),
+		    'status' => 'active',
+		  ),
+		  12 => 
+		  array (
+		    'meeting_id' => $this->meeting_ids[0],
+		    'instance_id' => $this->meeting_ids[0] . ':2020-02-26',
+		    'date' => '2020-02-26',
+		    'time' => '14:00:00',
+		    'datetime' => '2020-02-26T14:00:00+00:00',
+		    'team' => 'Team-A',
+		    'link' => 'wordpress.org',
+		    'title' => 'A weekly meeting',
+		    'location' => '#meta',
+		    'recurring' => 'weekly',
+		    'occurrence' => '',
 		    'status' => 'active',
 		  ),
 		);

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -75,7 +75,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
 		$this->assertGreaterThanOrEqual( 4, count( $meeting['future_occurrences'] ) );
-		$this->assertLessThanOrEqual( 6, count( $meeting['future_occurrences'] ) );
+		$this->assertLessThanOrEqual( 10, count( $meeting['future_occurrences'] ) );
 		// There should be no duplicates
 		$this->assertEquals( $meeting['future_occurrences'], array_unique( $meeting['future_occurrences'] ) );
 		$last = false;
@@ -88,6 +88,8 @@ class MeetingAPITest extends WP_UnitTestCase {
 			$dt = new DateTime( $future_date );
 			// It should be in the future
 			$this->assertGreaterThanOrEqual( new DateTime( 'yesterday' ), $dt );
+			// It should be within 2 months (the default range)
+			$this->assertLessThanOrEqual( new DateTime( '+2 months' ), $dt );
 			// Day of week should be Wednesday, same as the original
 			$this->assertEquals( 3, $dt->format( 'N' ) );
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -421,7 +421,10 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  5 => '2020-02-26T14:00:00+00:00',
 		  6 => '2020-03-01T15:00:00+00:00',
 		  7 => '2020-03-04T14:00:00+00:00',
-		  8 => '2020-03-18T16:00:00+00:00',
+		  8 => '2020-03-11T14:00:00+00:00',
+		  9 => '2020-03-18T14:00:00+00:00',
+		  10 => '2020-03-18T16:00:00+00:00',
+		  11 => '2020-03-25T14:00:00+00:00',
 		);
 		$this->assertEquals( $expected_datetimes, wp_list_pluck( $meetings, 'datetime' ) );
 
@@ -434,7 +437,10 @@ class MeetingAPITest extends WP_UnitTestCase {
 		  5 => 'Team-A',
 		  6 => 'Team-B',
 		  7 => 'Team-A',
-		  8 => 'Team-C',
+		  8 => 'Team-A',
+		  9 => 'Team-A',
+		  10 => 'Team-C',
+		  11 => 'Team-A',
 		);
 		$this->assertEquals( $expected_teams, wp_list_pluck( $meetings, 'team' ) );
 

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -83,12 +83,19 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 		) );
 
 		// Cancel the meeting that's in 6 days
-		$this->mpt->cancel_meeting( array( 'meeting_id' => $meeting_1, 'date' => strftime( '%Y-%m-%d', strtotime( 'yesterday + 6 days' ) ) ) );
+		$response = $this->mpt->cancel_meeting( array( 'meeting_id' => $meeting_1, 'date' => strftime( '%Y-%m-%d', strtotime( 'yesterday +7 days' ) ) ) );
+		$this->assertGreaterThan( 0, $response );
 
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
 
-		// The shortcode should show the next meeting is in 13 days
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +14 days' ) )) );
+		// The shortcode should show the next meeting is in 7 days
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) )) );
+
+		// It should be listed as cancelled
+		$this->assertGreaterThanOrEqual( 0, strpos( $actual, '<p class="wporg-meeting-shortcode meeting-cancelled"' ) );
+
+		// It should give the next date
+		$this->assertGreaterThan( 0, strpos( $actual, strftime( 'This event is cancelled. The next meeting is scheduled for %Y-%m-%d.', strtotime( 'yesterday +14 days' ) ) ) );
 	}
 }

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -59,9 +59,9 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong></br><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) )) );
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) )) );
 
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting Two</strong></br><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) )) );
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) )) );
 	}
 
 	function test_shortcode_cancelled() {
@@ -89,6 +89,6 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 
 
 		// The shortcode should show the next meeting is in 13 days
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong></br><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +14 days' ) )) );
+		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +14 days' ) )) );
 	}
 }


### PR DESCRIPTION
Most failures were due to behaviour that was correct but had changed slightly from when the tests were written.

Also fixes a real bug in the shortcode that turned up when I improved the test.