### PR TITLE
Leave padding until 960px

### DIFF
--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -251,18 +251,20 @@
 .wporg-meeting-calendar__header,
 .wporg-meeting-calendar__list,
 .wporg-meeting-calendar__filter {
-	padding: 8px;
+	padding: 12px;
 }
 
 @media (min-width: 600px) {
-	.wporg-meeting-calendar__header,
-	.wporg-meeting-calendar__list,
-	.wporg-meeting-calendar__filter {
-		padding: 0;
-	}
 	.wporg-meeting-calendar__list-event,
 	.wporg-meeting-calendar__list-event-details {
 		flex-direction: row;
+	}
+}
+
+@media (min-width: 960px) {
+	.wporg-meeting-calendar__header,
+	.wporg-meeting-calendar__list {
+		padding: 0;
 	}
 }
 
@@ -371,7 +373,6 @@
 	display: flex;
 	align-items: center;
 	border: 1px solid #ddd;
-	padding: 12px;
 	background: #eee;
 }
 


### PR DESCRIPTION
This PR:
- Leaves the padding around the container until `960px`.

Addresses: https://github.com/Automattic/meeting-calendar/issues/78