### PR TITLE
Add Editor Preview and move data fetching to its own context

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -82,14 +82,13 @@ function register_assets() {
 			$frontend_info['version'],
 			false
 		);
-
-		wp_register_style(
-			'wporg-calendar-style',
-			plugin_dir_url( __FILE__ ) . 'build/calendar.css',
-			array( 'wp-components' ),
-			$frontend_info['version']
-		);
 	}
+	wp_register_style(
+		'wporg-calendar-style',
+		plugin_dir_url( __FILE__ ) . 'build/calendar.css',
+		array( 'wp-components' ),
+		$frontend_info['version']
+	);
 
 	// Enqueue the script in the editor.
 	register_block_type(

--- a/src/edit.js
+++ b/src/edit.js
@@ -2,12 +2,16 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Placeholder } from '@wordpress/components';
+import { Disabled } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Calendar from './frontend/app';
 
 const EditView = () => (
-	<Placeholder
-		icon="calendar"
-		label={ __( 'Go to "Meetings" to add or edit your meetings', 'wporg' ) }
-	/>
+	<Disabled>
+		<Calendar />
+	</Disabled>
 );
 export default EditView;

--- a/src/frontend/app/index.js
+++ b/src/frontend/app/index.js
@@ -3,6 +3,7 @@
  */
 import { ViewProvider } from '../store/view-context';
 import { EventsProvider } from '../store/event-context';
+import { EventDataProvider } from '../store/data-context';
 import useWindowSize from '../store/hooks/use-window-size';
 import Calendar from '../calendar';
 
@@ -10,11 +11,13 @@ function App( { events } ) {
 	const { isSmall } = useWindowSize();
 
 	return (
-		<EventsProvider value={ events }>
+	<EventDataProvider>
+		<EventsProvider>
 			<ViewProvider isSmallViewport={ isSmall }>
 				<Calendar />
 			</ViewProvider>
 		</EventsProvider>
+	</EventDataProvider>
 	);
 }
 

--- a/src/frontend/app/index.js
+++ b/src/frontend/app/index.js
@@ -11,7 +11,7 @@ function App( { events } ) {
 	const { isSmall } = useWindowSize();
 
 	return (
-	<EventDataProvider>
+	<EventDataProvider data={ events } >
 		<EventsProvider>
 			<ViewProvider isSmallViewport={ isSmall }>
 				<Calendar />

--- a/src/frontend/store/data-context.js
+++ b/src/frontend/store/data-context.js
@@ -1,0 +1,45 @@
+
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext, useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { format } from '@wordpress/date';
+
+const EventDataContext = createContext( [] );
+
+export function useEventData() {
+	const context = useContext( EventDataContext );
+	if ( context === undefined ) {
+		throw new Error( 'useEvents must be used within a Provider' );
+	}
+	return context;
+}
+
+export function EventDataProvider( { children, data } ) {
+	const [ eventData, setEventData ] = useState( [] );
+	// we bail out early if data is hydrated from the server.
+	if ( data ) {
+		return (
+			<EventDataContext.Provider value={ data }>
+				{ children }
+			</EventDataContext.Provider>
+		);
+	}
+	useEffect(() => {
+		const currentDate = new Date();
+		const fromDate = new Date( currentDate.getFullYear(), currentDate.getMonth(), 1 );
+
+		apiFetch( {
+			path: `/wp/v2/meetings/from/${ format( 'Y-m-d', fromDate ) }`,
+	} ).then( events => {
+				setEventData( events )
+		} );
+
+	}, [ setEventData ])
+	return (
+		<EventDataContext.Provider value={ eventData }>
+			{ children }
+		</EventDataContext.Provider>
+	);
+}

--- a/src/frontend/store/data-context.js
+++ b/src/frontend/store/data-context.js
@@ -31,11 +31,10 @@ export function EventDataProvider( { children, data } ) {
 		const fromDate = new Date( currentDate.getFullYear(), currentDate.getMonth(), 1 );
 
 		apiFetch( {
-			path: `/wp/v2/meetings/from/${ format( 'Y-m-d', fromDate ) }`,
-	} ).then( events => {
+			path: `/wp/v2/meetings/from/${ format( 'Y-m-d', fromDate ) }?per_page=12`,
+		} ).then( events => {
 				setEventData( events )
 		} );
-
 	}, [ setEventData ])
 	return (
 		<EventDataContext.Provider value={ eventData }>

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -8,6 +8,7 @@ import { uniqBy } from 'lodash';
  * Internal dependencies
  */
 import { getSortedEvents } from './utils';
+import { useEventData } from './data-context';
 
 /**
  * Gets the team name if present in url.
@@ -37,20 +38,22 @@ function setTeamEffect( team = '' ) {
 
 const StateContext = createContext();
 
-export function EventsProvider( { children, value } ) {
+export function EventsProvider( { children } ) {
+	const events = useEventData();
+
 	const [ team, setTeam ] = useState( getTeamOnLoad() );
 
-	let eventsToDisplay = value;
+	let eventsToDisplay = events;
 
 	if ( team && team.trim().length ) {
-		eventsToDisplay = value.filter(
+		eventsToDisplay = events.filter(
 			( e ) => e.team.toLowerCase() === team.toLowerCase()
 		);
 	}
 
 	// Get a list of all teams available.
 	const teams = uniqBy(
-		value
+		events
 			.map( ( e ) => ( {
 				label: e.team,
 				value: e.team.toLowerCase(),


### PR DESCRIPTION
Hi!

First, thank you for this wonderful project, I always wanted to build one for a side project and to get to use one is wonderful.
Following my talk with Kelly in slack, she suggested I can contribute.

So this PR does some things, notably:
1- It introduces an Editor preview by simply rendering the App component in the editor.
for this to happen, I needed to create a new Context that fetches the data and pass it to EventProvider, I put it in a separate context to avoid calling the API each time the context updates, but I believe this can be mitigated if we save the fetch value in a ref and only fetch if that ref is `null`.
2- To keep compatibility, the context also accepts an optional data prop that has the event data, this allows us to hydrate the data from the server to avoid the initial request, using the same logic that was there.
3- This optional data will also allow us to pass a different kind of data to the editor, currently, I'm using real data, this can be swapped by a preview Data that can be passed the same way we pass the hydrated data

```js
const EditView = () => (
	<Disabled>
		<Calendar data={ previewData } />
	</Disabled>
);
```
4- we move `wporg-calendar-style` registration to outside admin as well, so that it can render on the editor. 

I'm also tagging @nerrad for a confidence check since I discussed some of those points with him.