### PR TITLE
Tools: Add wp-env, phpunit, phpcs

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,52 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  unit-php:
+    name: PHP Unit Tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache node modules
+      uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - name: Npm install and build
+      run: |
+        npm ci
+        npm run build
+
+    - name: composer install
+      run: |
+        composer install
+
+    - name: Install WordPress
+      run: |
+        chmod -R 767 ./ # TODO: Possibly integrate in wp-env
+        npm run wp-env start
+
+    - name: Running multisite unit tests
+      run: npm run test:unit-php
+      if: ${{ success() || failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 build/
 node_modules/
+vendor

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -26,9 +26,7 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP"/>
-	</rule>
+	<rule ref="WordPress" />
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,6 @@
+{
+	"core": "WordPress/WordPress",
+	"plugins": [
+		"."
+	]
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ This Meeting Calendar provides a way of scheduling recurring meetings, and displ
 6.  Create some meetings
 7.  While editing your page/post, add in the `Meeting Calendar` block and publish!
 
+## Development environment
+
+You can (optionally) use [`wp-env`](https://developer.wordpress.org/block-editor/packages/packages-env/) to set up a local environment.
+
+1. Install the node dependencies `npm install`
+2. Start the wp-env environment with `npm run wp-env start`
+3. Visit your new local environment at `http://localhost:8888`
+
+### Running PHPUnit Tests
+
+1. Install the composer dependencies `composer install`
+2. If you haven't yet, install the node dependencies `npm install`
+3. Start the wp-env environment with `npm run wp-env start`
+4. Run the tests with `npm run test:unit-php`
+
 ## License
 
 Meeting Calendar is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+	"name": "wporg/meeting-calendar",
+	"description": "",
+	"homepage": "https://make.wordpress.org/meetings",
+	"license": "GPL-2.0-or-later",
+	"support": {
+		"issues": "https://github.com/Automattic/meeting-calendar/issues"
+	},
+	"config": {
+		"platform": {
+			"php": "7.2"
+		}
+	},
+	"repositories": [
+		{
+			"type": "composer",
+			"url": "https://wpackagist.org/"
+		}
+	],
+	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+		"wp-coding-standards/wpcs": "2.*",
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"wp-phpunit/wp-phpunit": "^5.4",
+		"phpunit/phpunit": "^7.5.20"
+	},
+	"scripts": {
+		"format": "phpcbf -p",
+		"lint": "phpcs"
+	}
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2106 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "64acf47305b7e542123ad7bb88d7da5c",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2021-02-15T10:24:51+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2021-02-15T12:58:46+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
+            "time": "2020-09-03T19:13:55+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
+            "time": "2020-09-17T18:55:26+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.12.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+            },
+            "time": "2020-12-19T10:15:11+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/master"
+            },
+            "time": "2018-10-31T16:06:48+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:25:21+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-11-30T08:38:46+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.5.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpunit/phpunit-mock-objects": "*"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.20"
+            },
+            "time": "2020-01-08T08:45:45+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+            },
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2020-10-23T02:01:07+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+            },
+            "time": "2020-07-08T17:02:28+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "f6b3fb65bccc0ff70b3bc7cc241935597dbd5562"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/f6b3fb65bccc0ff70b3bc7cc241935597dbd5562",
+                "reference": "f6b3fb65bccc0ff70b3bc7cc241935597dbd5562",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://github.com/wp-phpunit/docs",
+                "issues": "https://github.com/wp-phpunit/issues",
+                "source": "https://github.com/wp-phpunit/wp-phpunit"
+            },
+            "time": "2021-02-04T18:24:14+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2"
+    },
+    "plugin-api-version": "2.0.0"
+}

--- a/includes/ical-functions.php
+++ b/includes/ical-functions.php
@@ -1,7 +1,7 @@
 <?php
 namespace WordPressdotorg\Meeting_Calendar\ICS;
 
-define( 'QUERY_KEY',      'meeting_ical' );
+define( 'QUERY_KEY', 'meeting_ical' );
 define( 'QUERY_TEAM_KEY', 'meeting_team' );
 
 /**
@@ -49,7 +49,7 @@ function parse_request( $request ) {
 
 	$team = strtolower( $request->query_vars[ QUERY_TEAM_KEY ] );
 
-	// Grab the meetings, optionally 
+	// Grab the meetings, optionally
 	$posts = get_meeting_posts( $team );
 
 	// Output a 404 if there's no meetings, but still generate a ICS feed.
@@ -78,26 +78,27 @@ add_action( 'parse_request', __NAMESPACE__ . '\parse_request' );
  * @return array
  */
 function get_meeting_posts( $team = '' ) {
-
 	$meta_query = \Meeting_Post_Type::getInstance()->meeting_meta_query();
 	if ( $team ) {
-		$meta_query = [
+		$meta_query = array(
 			'relation' => 'AND',
-			[
+			array(
 				'key'     => 'team',
 				'value'   => $team,
 				'compare' => 'EQUALS',
-			],
-			$meta_query
-		];
+			),
+			$meta_query,
+		);
 	}
 
-	$query = new \WP_Query( [
-		'post_type'   => 'meeting',
-		'post_status' => 'publish',
-		'nopaging'    => true,
-		'meta_query'  => $meta_query,
-	] );
+	$query = new \WP_Query(
+		array(
+			'post_type'   => 'meeting',
+			'post_status' => 'publish',
+			'nopaging'    => true,
+			'meta_query'  => $meta_query,
+		)
+	);
 
 	return $query->get_posts();
 }

--- a/includes/ical-generator-functions.php
+++ b/includes/ical-generator-functions.php
@@ -101,7 +101,7 @@ function generate_event( $post ) {
 					$cancelled[ $i ] = strftime( '%Y%m%d', $exdate );
 				}
 			}
-			$event .= "EXDATE:" . implode( ',', $cancelled ) . NEWLINE;
+			$event .= 'EXDATE:' . implode( ',', $cancelled ) . NEWLINE;
 		}
 	}
 
@@ -139,7 +139,7 @@ function get_frequency( $recurrence, $date, $occurrences ) {
  *   $date = '2019-09-15' // the day is Sunday
  * it will return: 'MONTHLY;BYDAY=1SU,3SU'
  *
- * @param array $occurrences
+ * @param array  $occurrences
  * @param string $date
  * @return string
  */

--- a/includes/wporg-meeting-install.php
+++ b/includes/wporg-meeting-install.php
@@ -6,61 +6,65 @@ namespace WordPressdotorg\Meeting_Calendar;
 */
 
 function wporg_meeting_install() {
-
-	if ( wp_count_posts('meeting')->publish + wp_count_posts('meeting')->draft <= 0 ) {
+	if ( wp_count_posts( 'meeting' )->publish + wp_count_posts( 'meeting' )->draft <= 0 ) {
 		// No posts of any status exist, so insert a few sample meetings.
 
 		$meeting_ids = array();
 
-		$meeting_ids[] = wp_insert_post( array(
-			'post_title' => __( 'A weekly meeting', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-A',
-				'start_date' => '2020-01-01',
-				'end_date'   => '',
-				'time'       => '14:00:00',
-				'recurring'  => 'weekly',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_ids[] = wp_insert_post(
+			array(
+				'post_title'  => __( 'A weekly meeting', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-A',
+					'start_date' => '2020-01-01',
+					'end_date'   => '',
+					'time'       => '14:00:00',
+					'recurring'  => 'weekly',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
-		$meeting_ids[] = wp_insert_post( array(
-			'post_title' => __( 'A monthly meeting', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-B',
-				'start_date' => '2020-01-01',
-				'end_date'   => '',
-				'time'       => '15:00:00',
-				'recurring'  => 'monthly',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_ids[] = wp_insert_post(
+			array(
+				'post_title'  => __( 'A monthly meeting', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-B',
+					'start_date' => '2020-01-01',
+					'end_date'   => '',
+					'time'       => '15:00:00',
+					'recurring'  => 'monthly',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
-		$meeting_ids[] = wp_insert_post( array(
-			'post_title' => __( 'Third Wednesday of each month', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-C',
-				'start_date' => '2020-01-01',
-				'end_date'   => '',
-				'time'       => '16:00:00',
-				'recurring'  => 'occurrence',
-				'occurrence' => array( 3 ),
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_ids[] = wp_insert_post(
+			array(
+				'post_title'  => __( 'Third Wednesday of each month', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-C',
+					'start_date' => '2020-01-01',
+					'end_date'   => '',
+					'time'       => '16:00:00',
+					'recurring'  => 'occurrence',
+					'occurrence' => array( 3 ),
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
 		flush_rewrite_rules();
 
 		return $meeting_ids;
 	}
-	
 }

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -9,440 +9,466 @@ Author URI:  http://wordpress.org/
 Text Domain: wporg
 */
 
-if ( !class_exists('Meeting_Post_Type') ):
-class Meeting_Post_Type {
+if ( ! class_exists( 'Meeting_Post_Type' ) ) :
+	class Meeting_Post_Type {
 
-	protected static $instance = NULL;
+		protected static $instance = null;
 
-	public static function getInstance() {
-		NULL === self::$instance and self::$instance = new self;
-		return self::$instance;
-	}
+		public static function getInstance() {
+			null === self::$instance and self::$instance = new self();
+			return self::$instance;
+		}
 
-	public static function init() {
-		$mpt = Meeting_Post_Type::getInstance();
-		add_action( 'init',                               array( $mpt, 'register_meeting_post_type' ) );
-		add_action( 'init',                               array( $mpt, 'register_meta' ) );
-		add_action( 'rest_api_init',                      array( $mpt, 'register_rest_field' ) );
-		add_action( 'rest_api_init',                      array( $mpt, 'register_rest_routes' ) );
-		add_action( 'save_post_meeting',                  array( $mpt, 'save_meta_boxes' ), 10, 2 );
-		add_filter( 'pre_get_posts',                      array( $mpt, 'meeting_archive_page_query' ) );
-		add_filter( 'the_posts',                          array( $mpt, 'meeting_set_next_meeting' ), 10, 2 );
-		add_filter( 'manage_meeting_posts_columns',       array( $mpt, 'meeting_add_custom_columns' ) );
-		add_action( 'manage_meeting_posts_custom_column', array( $mpt, 'meeting_custom_columns' ), 10, 2 );
-		add_action( 'admin_head',                         array( $mpt, 'meeting_column_width' ) );
-		add_action( 'admin_bar_menu',                     array( $mpt, 'add_edit_meetings_item_to_admin_bar' ), 80 );
-		add_action( 'wp_enqueue_scripts',                 array( $mpt, 'add_edit_meetings_icon_to_admin_bar' ) );
-		add_shortcode( 'meeting_time',                    array( $mpt, 'meeting_time_shortcode' ) );
+		public static function init() {
+			$mpt = self::getInstance();
+			add_action( 'init', array( $mpt, 'register_meeting_post_type' ) );
+			add_action( 'init', array( $mpt, 'register_meta' ) );
+			add_action( 'rest_api_init', array( $mpt, 'register_rest_field' ) );
+			add_action( 'rest_api_init', array( $mpt, 'register_rest_routes' ) );
+			add_action( 'save_post_meeting', array( $mpt, 'save_meta_boxes' ), 10, 2 );
+			add_filter( 'pre_get_posts', array( $mpt, 'meeting_archive_page_query' ) );
+			add_filter( 'the_posts', array( $mpt, 'meeting_set_next_meeting' ), 10, 2 );
+			add_filter( 'manage_meeting_posts_columns', array( $mpt, 'meeting_add_custom_columns' ) );
+			add_action( 'manage_meeting_posts_custom_column', array( $mpt, 'meeting_custom_columns' ), 10, 2 );
+			add_action( 'admin_head', array( $mpt, 'meeting_column_width' ) );
+			add_action( 'admin_bar_menu', array( $mpt, 'add_edit_meetings_item_to_admin_bar' ), 80 );
+			add_action( 'wp_enqueue_scripts', array( $mpt, 'add_edit_meetings_icon_to_admin_bar' ) );
+			add_shortcode( 'meeting_time', array( $mpt, 'meeting_time_shortcode' ) );
 
-		// shortcodes aren't normally processed in widgets, add this to allow meeting_type in text widgets
-		// TODO make this more specific and only add this shortcode to widget processing
-		add_filter( 'widget_text', 'do_shortcode' );
-	}
+			// shortcodes aren't normally processed in widgets, add this to allow meeting_type in text widgets
+			// TODO make this more specific and only add this shortcode to widget processing
+			add_filter( 'widget_text', 'do_shortcode' );
+		}
 
-	public function meeting_column_width() { ?>
+		public function meeting_column_width() { ?>
 		<style type="text/css">
 			.column-team { width: 10em !important; overflow: hidden; }
 			#meeting-info .recurring label { padding-right: 10px; }
 		</style>
-		<?php
-	}
+			<?php
+		}
 
-	public function meeting_add_custom_columns( $columns ) {
-		$columns = array_slice( $columns, 0, 1, true )
-			+ array( 'team' => __('Team', 'wporg') )
+		public function meeting_add_custom_columns( $columns ) {
+			$columns = array_slice( $columns, 0, 1, true )
+			+ array( 'team' => __( 'Team', 'wporg' ) )
 			+ array_slice( $columns, 1, null, true );
-		return $columns;
-	}
-
-	public function meeting_custom_columns( $column, $post_id ) {
-		switch ( $column ) {
-		case 'team' :
-			$team = get_post_meta( $post_id, 'team', true );
-			echo esc_html( $team );
-			break;
+			return $columns;
 		}
-	}
 
-	public function meeting_archive_page_query( $query ) {
-		if ( is_admin() || ! $query->is_main_query() || ! $query->is_post_type_archive( 'meeting' ) ) {
-			return;
+		public function meeting_custom_columns( $column, $post_id ) {
+			switch ( $column ) {
+				case 'team':
+					$team = get_post_meta( $post_id, 'team', true );
+					echo esc_html( $team );
+					break;
+			}
 		}
-		// turn off paging on the archive page, to show all meetings in the table
-		$query->set( 'nopaging', true );
 
-		// meta query to eliminate expired meetings from query
-		$query->set( 'meta_query', $this->meeting_meta_query() );
-	}
+		public function meeting_archive_page_query( $query ) {
+			if ( is_admin() || ! $query->is_main_query() || ! $query->is_post_type_archive( 'meeting' ) ) {
+				return;
+			}
+			// turn off paging on the archive page, to show all meetings in the table
+			$query->set( 'nopaging', true );
 
-	public function meeting_set_next_meeting( $posts, $query ) {
-		if ( !$query->is_post_type_archive( 'meeting' ) ) {
+			// meta query to eliminate expired meetings from query
+			$query->set( 'meta_query', $this->meeting_meta_query() );
+		}
+
+		public function meeting_set_next_meeting( $posts, $query ) {
+			if ( ! $query->is_post_type_archive( 'meeting' ) ) {
+				return $posts;
+			}
+
+			// for each entry, set a fake meta value to show the next date for recurring meetings
+			array_walk(
+				$posts,
+				function ( &$post ) {
+					if ( 'meeting' !== $post->post_type ) {
+						return false;
+					}
+					$next = $this->get_next_occurrence( $post );
+					if ( $next ) {
+						$post->next_date = $next;
+					} else {
+						// if the datetime is invalid, then set the post->next_date to the start date instead
+						$post->next_date = $post->start_date;
+					}
+				}
+			);
+
+			// reorder the posts by next_date + time
+			usort(
+				$posts,
+				function ( $a, $b ) {
+					$adate = strtotime( $a->next_date . ' ' . $a->time );
+					$bdate = strtotime( $b->next_date . ' ' . $b->time );
+					if ( $adate == $bdate ) {
+						return 0;
+					}
+					return ( $adate < $bdate ) ? -1 : 1;
+				}
+			);
+
 			return $posts;
 		}
-		
-		// for each entry, set a fake meta value to show the next date for recurring meetings
-		array_walk( $posts, function ( &$post ) {
-			if ( 'meeting' !== $post->post_type ) {
+
+		/*
+		 * Returns the date of the next occurrence of the meeting.
+		 *
+		 * @param object $post A meeting post object.
+		 * @param string $after_datetime Find the next occurrence after this date.
+		 *
+		 * @return string|bool A date string representing the date of the next occurrence; false if there is no next meeting.
+		 */
+		function get_next_occurrence( $post, $after_datetime = '-30 minutes' ) {
+			if ( ! is_object( $post ) || 'meeting' !== $post->post_type ) {
 				return false;
 			}
-			$next = $this->get_next_occurrence( $post );
-			if ( $next ) {
-				$post->next_date = $next;
-			} else {
-				// if the datetime is invalid, then set the post->next_date to the start date instead
-				$post->next_date = $post->start_date;
-			}
-		});
 
-		// reorder the posts by next_date + time
-		usort( $posts, function ($a, $b) {
-			$adate = strtotime( $a->next_date . ' ' . $a->time );
-			$bdate = strtotime( $b->next_date . ' ' . $b->time );
-			if ( $adate == $bdate ) {
-				return 0;
-			}
-			return ( $adate < $bdate ) ? -1 : 1;
-		});
+			$next_date = false;
 
-		return $posts;
-	}
+			if ( 'weekly' === $post->recurring || '1' === $post->recurring ) {
+				try {
+					// from the start date, advance the week until it's past now
+					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+					$next  = $start;
+					// minus 30 minutes to account for currently ongoing meetings
+					$now = new DateTime( $after_datetime );
 
-	/*
-	 * Returns the date of the next occurrence of the meeting.
-	 *
-	 * @param object $post A meeting post object.
-	 * @param string $after_datetime Find the next occurrence after this date.
-	 *
-	 * @return string|bool A date string representing the date of the next occurrence; false if there is no next meeting.
-	 */
-	function get_next_occurrence( $post, $after_datetime = '-30 minutes' ) {
-		if ( !is_object( $post ) || 'meeting' !== $post->post_type )
-			return false;
-
-		$next_date = false;
-
-		if ( 'weekly' === $post->recurring || '1' === $post->recurring ) {
-			try {
-				// from the start date, advance the week until it's past now
-				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-				$next  = $start;
-				// minus 30 minutes to account for currently ongoing meetings
-				$now   = new DateTime( $after_datetime );
-
-				if ( $next <= $now ) {
-					$interval = $start->diff( $now );
-					// add one to days to account for events that happened earlier today
-					$weekdiff = ceil( ( $interval->days + 1 ) / 7 );
-					$next->modify( '+ ' . $weekdiff . ' weeks' );
-				}
-
-				$next_date = $next->format( 'Y-m-d' );
-			} catch ( Exception $e ) {
-				$next_date = false;
-			}
-		} else if ( 'biweekly' === $post->recurring ) {
-			try {
-				// advance the start date 2 weeks at a time until it's past now
-				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-				$next  = $start;
-				// minus 30 minutes to account for currently ongoing meetings
-				$now   = new DateTime( $after_datetime );
-
-				while ( $next <= $now ) {
-					$next->modify( '+2 weeks' );
-				}
-
-				$next_date = $next->format( 'Y-m-d' );
-			} catch ( Exception $e ) {
-				$next_date = false;
-			}
-		} else if ( 'occurrence' === $post->recurring ) {
-			try {
-				// advance the occurrence day in the current month until it's past now
-				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-				$next  = $start;
-				// minus 30 minutes to account for currently ongoing meetings
-				$now   = new DateTime( $after_datetime );
-
-				$day_index = date( 'w', strtotime( sprintf( '%s %s GMT', $post->start_date, $post->time ) ) );
-				$day_name  = $GLOBALS['wp_locale']->get_weekday( $day_index );
-				$numerals  = array( 'first', 'second', 'third', 'fourth' );
-				$months    = array( 'last month', 'this month', 'next month', "+2 month" );
-
-				$next = clone $now;
-
-				$limit = 12;
-				do {
-					$month_year = $next->format( 'F Y' );
-					foreach ( $post->occurrence as $index ) {
-						$next = new DateTime( sprintf( '%s %s of %s %s GMT', $numerals[ $index - 1 ], $day_name, $month_year, $post->time ) );
-						if ( $next > $now ) {
-							break 2;
-						}
+					if ( $next <= $now ) {
+						$interval = $start->diff( $now );
+						// add one to days to account for events that happened earlier today
+						$weekdiff = ceil( ( $interval->days + 1 ) / 7 );
+						$next->modify( '+ ' . $weekdiff . ' weeks' );
 					}
-					$next->modify( '+1 month' );
-				} while ( --$limit > 0 );
-				$next_date = $next->format( 'Y-m-d' );
-			} catch ( Exception $e ) {
-				$next_date = false;
-			}
-		} else if ( 'monthly' === $post->recurring ) {
-			try {
-				// advance the start date 1 month at a time until it's past now
-				$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
-				$next  = $start;
-				// minus 30 minutes to account for currently ongoing meetings
-				$now   = new DateTime( $after_datetime );
 
-				while ( $next <= $now ) {
-					$next->modify( '+1 month' );
+					$next_date = $next->format( 'Y-m-d' );
+				} catch ( Exception $e ) {
+					$next_date = false;
 				}
+			} elseif ( 'biweekly' === $post->recurring ) {
+				try {
+					// advance the start date 2 weeks at a time until it's past now
+					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+					$next  = $start;
+					// minus 30 minutes to account for currently ongoing meetings
+					$now = new DateTime( $after_datetime );
 
-				$next_date = $next->format( 'Y-m-d' );
-			} catch ( Exception $e ) {
-				$next_date = false;
+					while ( $next <= $now ) {
+						$next->modify( '+2 weeks' );
+					}
+
+					$next_date = $next->format( 'Y-m-d' );
+				} catch ( Exception $e ) {
+					$next_date = false;
+				}
+			} elseif ( 'occurrence' === $post->recurring ) {
+				try {
+					// advance the occurrence day in the current month until it's past now
+					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+					$next  = $start;
+					// minus 30 minutes to account for currently ongoing meetings
+					$now = new DateTime( $after_datetime );
+
+					$day_index = date( 'w', strtotime( sprintf( '%s %s GMT', $post->start_date, $post->time ) ) );
+					$day_name  = $GLOBALS['wp_locale']->get_weekday( $day_index );
+					$numerals  = array( 'first', 'second', 'third', 'fourth' );
+					$months    = array( 'last month', 'this month', 'next month', '+2 month' );
+
+					$next = clone $now;
+
+					$limit = 12;
+					do {
+						$month_year = $next->format( 'F Y' );
+						foreach ( $post->occurrence as $index ) {
+							$next = new DateTime( sprintf( '%s %s of %s %s GMT', $numerals[ $index - 1 ], $day_name, $month_year, $post->time ) );
+							if ( $next > $now ) {
+								break 2;
+							}
+						}
+						$next->modify( '+1 month' );
+					} while ( --$limit > 0 );
+					$next_date = $next->format( 'Y-m-d' );
+				} catch ( Exception $e ) {
+					$next_date = false;
+				}
+			} elseif ( 'monthly' === $post->recurring ) {
+				try {
+					// advance the start date 1 month at a time until it's past now
+					$start = new DateTime( sprintf( '%s %s GMT', $post->start_date, $post->time ) );
+					$next  = $start;
+					// minus 30 minutes to account for currently ongoing meetings
+					$now = new DateTime( $after_datetime );
+
+					while ( $next <= $now ) {
+						$next->modify( '+1 month' );
+					}
+
+					$next_date = $next->format( 'Y-m-d' );
+				} catch ( Exception $e ) {
+					$next_date = false;
+				}
+			} else {
+				$next_date = $post->start_date;
 			}
-		} else {
-			$next_date = $post->start_date;
+
+			return $next_date;
 		}
 
-		return $next_date;
-	}
+		public function register_meeting_post_type() {
+			$labels = array(
+				'name'               => _x( 'Meetings', 'Post Type General Name', 'wporg' ),
+				'singular_name'      => _x( 'Meeting', 'Post Type Singular Name', 'wporg' ),
+				'menu_name'          => __( 'Meetings', 'wporg' ),
+				'name_admin_bar'     => __( 'Meeting', 'wporg' ),
+				'parent_item_colon'  => __( 'Parent Meeting:', 'wporg' ),
+				'all_items'          => __( 'All Meetings', 'wporg' ),
+				'add_new_item'       => __( 'Add New Meeting', 'wporg' ),
+				'add_new'            => __( 'Add New', 'wporg' ),
+				'new_item'           => __( 'New Meeting', 'wporg' ),
+				'edit_item'          => __( 'Edit Meeting', 'wporg' ),
+				'update_item'        => __( 'Update Meeting', 'wporg' ),
+				'view_item'          => __( 'View Meeting', 'wporg' ),
+				'view_items'         => __( 'View Meetings', 'wporg' ),
+				'search_items'       => __( 'Search Meeting', 'wporg' ),
+				'not_found'          => __( 'Not found', 'wporg' ),
+				'not_found_in_trash' => __( 'Not found in Trash', 'wporg' ),
+			);
+			$args   = array(
+				'label'                => __( 'meeting', 'wporg' ),
+				'description'          => __( 'Meeting', 'wporg' ),
+				'labels'               => $labels,
+				'supports'             => array( 'title', 'custom-fields' ),
+				'hierarchical'         => false,
+				'public'               => true,
+				'show_ui'              => true,
+				'show_in_menu'         => true,
+				'menu_position'        => 20,
+				'menu_icon'            => 'dashicons-calendar',
+				'show_in_admin_bar'    => true,
+				'show_in_nav_menus'    => false,
+				'show_in_rest'         => true,
+				'can_export'           => false,
+				'has_archive'          => false,
+				'exclude_from_search'  => true,
+				'publicly_queryable'   => true,
+				'capability_type'      => 'post',
+				'register_meta_box_cb' => array( $this, 'add_meta_boxes' ),
+				'rewrite'              => false,
+			);
+			register_post_type( 'meeting', $args );
+		}
 
-	public function register_meeting_post_type() {
-	    $labels = array(
-	        'name'                => _x( 'Meetings', 'Post Type General Name', 'wporg' ),
-	        'singular_name'       => _x( 'Meeting', 'Post Type Singular Name', 'wporg' ),
-	        'menu_name'           => __( 'Meetings', 'wporg' ),
-	        'name_admin_bar'      => __( 'Meeting', 'wporg' ),
-	        'parent_item_colon'   => __( 'Parent Meeting:', 'wporg' ),
-	        'all_items'           => __( 'All Meetings', 'wporg' ),
-	        'add_new_item'        => __( 'Add New Meeting', 'wporg' ),
-	        'add_new'             => __( 'Add New', 'wporg' ),
-	        'new_item'            => __( 'New Meeting', 'wporg' ),
-	        'edit_item'           => __( 'Edit Meeting', 'wporg' ),
-	        'update_item'         => __( 'Update Meeting', 'wporg' ),
-	        'view_item'           => __( 'View Meeting', 'wporg' ),
-	        'view_items'          => __( 'View Meetings', 'wporg' ),
-	        'search_items'        => __( 'Search Meeting', 'wporg' ),
-	        'not_found'           => __( 'Not found', 'wporg' ),
-	        'not_found_in_trash'  => __( 'Not found in Trash', 'wporg' ),
-	    );
-	    $args = array(
-	        'label'               => __( 'meeting', 'wporg' ),
-	        'description'         => __( 'Meeting', 'wporg' ),
-	        'labels'              => $labels,
-	        'supports'            => array( 'title', 'custom-fields' ),
-	        'hierarchical'        => false,
-	        'public'              => true,
-	        'show_ui'             => true,
-	        'show_in_menu'        => true,
-	        'menu_position'       => 20,
-	        'menu_icon'           => 'dashicons-calendar',
-	        'show_in_admin_bar'   => true,
-	        'show_in_nav_menus'   => false,
-	        'show_in_rest'        => true,
-	        'can_export'          => false,
-	        'has_archive'         => false,
-	        'exclude_from_search' => true,
-	        'publicly_queryable'  => true,
-	        'capability_type'     => 'post',
-			'register_meta_box_cb'=> array( $this, 'add_meta_boxes' ),
-			'rewrite'             => false,
-	    );
-		register_post_type( 'meeting', $args );		
-	}
-
-	public function register_meta() {
-		// Most are string types
-		$meta_keys = array(
-			'team',
-			'start_date',
-			'end_date',
-			'time',
-			'recurring',
-			'link',
-			'location',
-		);
-		foreach ( $meta_keys as $key ) {
-			register_meta( 'post', $key, array(
+		public function register_meta() {
+			// Most are string types
+			$meta_keys = array(
+				'team',
+				'start_date',
+				'end_date',
+				'time',
+				'recurring',
+				'link',
+				'location',
+			);
+			foreach ( $meta_keys as $key ) {
+				register_meta(
+					'post',
+					$key,
+					array(
+						'object_subtype' => 'meeting',
+						'type'           => 'string',
+						'single'         => true,
+						'show_in_rest'   => true,
+					)
+				);
+			}
+			// 'occurrence' is an array of strings
+			register_meta(
+				'post',
+				'occurrence',
+				array(
 					'object_subtype' => 'meeting',
-					'type' => 'string',
-					'single' => true,
-					'show_in_rest' => true,
+					'type'           => 'array',
+					'single'         => true,
+					'show_in_rest'   => array(
+						'schema' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type' => 'integer',
+							),
+						),
+					),
 				)
 			);
 		}
-		// 'occurrence' is an array of strings
-		register_meta( 'post', 'occurrence', array(
-				'object_subtype' => 'meeting',
-				'type' => 'array',
-				'single' => true,
-				'show_in_rest' => array(
-					'schema' => array(
-						'type' => 'array',
-						'items' => array(
-							'type' => 'integer',
-						)
-					)
-				),
-			)
-		);
-	}
 
-	public function register_rest_field() {
-		register_rest_field( 'meeting', 'future_occurrences', array(
-			'get_callback' => array( $this, 'get_future_occurrences' )
-			)
-		);	
-	}
+		public function register_rest_field() {
+			register_rest_field(
+				'meeting',
+				'future_occurrences',
+				array(
+					'get_callback' => array( $this, 'get_future_occurrences' ),
+				)
+			);
+		}
 
-	public function is_meeting_cancelled( $meeting_id, $date ) {
-		// Note: this assumes the meeting does occur on $date
-		$cancellations = get_post_meta( $meeting_id, 'meeting_cancelled', false );
-		return in_array( $date, $cancellations, true );
-	}
+		public function is_meeting_cancelled( $meeting_id, $date ) {
+			// Note: this assumes the meeting does occur on $date
+			$cancellations = get_post_meta( $meeting_id, 'meeting_cancelled', false );
+			return in_array( $date, $cancellations, true );
+		}
 
-	public function get_occurrences_for_period( $request ) {
-		$meetings = get_posts( array( 
-			'post_type' => 'meeting',
-			'post_status' => 'publish',
-			'numberposts' => -1,
-		) );
-		$out = array();
-		foreach ( $meetings as $meeting ) {
-			$occurrences = $this->get_future_occurrences( $meeting, null, $request );
-			foreach ( $occurrences as $occurrence ) {
-				$meeting->time = strftime( '%H:%M:%S', strtotime( $meeting->time ) );
-				$out[] = array(
-					'meeting_id'  => $meeting->ID,
-					'instance_id' => "{$meeting->ID}:{$occurrence}",
-					'date'        => $occurrence,
-					'time'        => $meeting->time,
-					'datetime'    => "{$occurrence}T{$meeting->time}+00:00",
-					'team'        => $meeting->team,
-					'link'        => $meeting->link,
-					'title'       => wp_specialchars_decode( $meeting->post_title, ENT_QUOTES ),
-					'location'    => $meeting->location,
-					'recurring'   => $meeting->recurring,
-					'occurrence'  => $meeting->occurrence,
-					'status'      => ( $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ? 'cancelled' : 'active' ),
-				);
+		public function get_occurrences_for_period( $request ) {
+			$meetings = get_posts(
+				array(
+					'post_type'   => 'meeting',
+					'post_status' => 'publish',
+					'numberposts' => -1,
+				)
+			);
+			$out      = array();
+			foreach ( $meetings as $meeting ) {
+				$occurrences = $this->get_future_occurrences( $meeting, null, $request );
+				foreach ( $occurrences as $occurrence ) {
+					$meeting->time = strftime( '%H:%M:%S', strtotime( $meeting->time ) );
+					$out[]         = array(
+						'meeting_id'  => $meeting->ID,
+						'instance_id' => "{$meeting->ID}:{$occurrence}",
+						'date'        => $occurrence,
+						'time'        => $meeting->time,
+						'datetime'    => "{$occurrence}T{$meeting->time}+00:00",
+						'team'        => $meeting->team,
+						'link'        => $meeting->link,
+						'title'       => wp_specialchars_decode( $meeting->post_title, ENT_QUOTES ),
+						'location'    => $meeting->location,
+						'recurring'   => $meeting->recurring,
+						'occurrence'  => $meeting->occurrence,
+						'status'      => ( $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ? 'cancelled' : 'active' ),
+					);
+				}
 			}
+
+			usort(
+				$out,
+				function( $a, $b ) {
+					return $a['datetime'] <=> $b['datetime'];
+				}
+			);
+			return $out;
 		}
 
-		usort( $out, function( $a, $b ) {
-			return $a['datetime'] <=> $b['datetime']; 
-		} );
-		return $out;
-	}
-
-	public function register_rest_routes() {
-		register_rest_route(
-			'wp/v2/meetings',
-			'/from/(?P<month>\d\d\d\d-\d\d-\d\d)',
-			array(
-				'methods' => 'GET',
-				'callback' => array( $this, 'get_occurrences_for_period' ),
-				'permission_callback' => '__return_true',
-			)
-		);
-		register_rest_route( 'wp/v2/meetings', '/(?P<meeting_id>\d+):(?P<date>\d\d\d\d-\d\d-\d\d)', array(
-			array(
-				'methods' => 'DELETE',
-				'callback' => array( $this, 'cancel_meeting'),
-				'permission_callback' => array( $this, 'can_cancel_meeting' ),
-			),
-			array(
-				'methods' => 'PUT',
-				'callback' => array( $this, 'uncancel_meeting'),
-				'permission_callback' => array( $this, 'can_cancel_meeting' ),
-			)
-		) );
-	}
-
-	public function cancel_meeting( $request ) {
-		// TODO: should validate that the meeting does occur on the given date
-		return add_post_meta( $request['meeting_id'], 'meeting_cancelled', $request['date'], false );
-	}
-
-	public function uncancel_meeting( $request ) {
-		return delete_post_meta( $request['meeting_id'], 'meeting_cancelled', $request['date'] );
-	}
-
-	public function can_cancel_meeting( $request ) {
-		return current_user_can( 'edit_post', $request['meeting_id'] );
-	}
-
-	public function get_future_occurrences( $meeting, $attr, $request ) {
-		if ( is_array( $meeting ) && !empty( $meeting['id'] ) ) {
-			// The register_rest_field callback passes a prepared array but we need the post object
-			$meeting = get_post( $meeting['id'] );
+		public function register_rest_routes() {
+			register_rest_route(
+				'wp/v2/meetings',
+				'/from/(?P<month>\d\d\d\d-\d\d-\d\d)',
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_occurrences_for_period' ),
+					'permission_callback' => '__return_true',
+				)
+			);
+			register_rest_route(
+				'wp/v2/meetings',
+				'/(?P<meeting_id>\d+):(?P<date>\d\d\d\d-\d\d-\d\d)',
+				array(
+					array(
+						'methods'             => 'DELETE',
+						'callback'            => array( $this, 'cancel_meeting' ),
+						'permission_callback' => array( $this, 'can_cancel_meeting' ),
+					),
+					array(
+						'methods'             => 'PUT',
+						'callback'            => array( $this, 'uncancel_meeting' ),
+						'permission_callback' => array( $this, 'can_cancel_meeting' ),
+					),
+				)
+			);
 		}
 
-		// The month the occurrences should be within.
-		// Passed to the API endpoint as /meetings?month=2020-09-01
-		$now = time();
-		if ( isset( $request['month'] ) ) {
-			$now = strtotime( $request['month'] );
+		public function cancel_meeting( $request ) {
+			// TODO: should validate that the meeting does occur on the given date
+			return add_post_meta( $request['meeting_id'], 'meeting_cancelled', $request['date'], false );
 		}
 
-		$from = DateTime::createFromFormat( 'U', strtotime( '-30 minutes', $now ) );
-		$end  = DateTime::createFromFormat( 'U', strtotime( '+2 month', $now ) );
-		if ( $meeting->end_date ) {
-			$end = DateTime::createFromFormat( 'Y-m-d', $meeting->end_date );
+		public function uncancel_meeting( $request ) {
+			return delete_post_meta( $request['meeting_id'], 'meeting_cancelled', $request['date'] );
 		}
-		$max  = 12;
-		$occurrences = array();
-		do {
-			$next = $this->get_next_occurrence( $meeting, $from->format( 'Y-m-d H:i:s P' ) );
-			if ( $next ) {
-				$from = new DateTime( "{$next} {$meeting->time}" );
-				if ( $from <= $end )
-					$occurrences[] = $next;
+
+		public function can_cancel_meeting( $request ) {
+			return current_user_can( 'edit_post', $request['meeting_id'] );
+		}
+
+		public function get_future_occurrences( $meeting, $attr, $request ) {
+			if ( is_array( $meeting ) && ! empty( $meeting['id'] ) ) {
+				// The register_rest_field callback passes a prepared array but we need the post object
+				$meeting = get_post( $meeting['id'] );
 			}
-		} while ( --$max > 0 && $next && $from && $from < $end && $meeting->recurring );
 
-		return $occurrences;
-	}
+			// The month the occurrences should be within.
+			// Passed to the API endpoint as /meetings?month=2020-09-01
+			$now = time();
+			if ( isset( $request['month'] ) ) {
+				$now = strtotime( $request['month'] );
+			}
 
-	public function add_meta_boxes() {
-		add_meta_box(
-			'meeting-info',
-			'Meeting Info',
-			array( $this, 'render_meta_boxes' ),
-			'meeting',
-			'normal',
-			'high'
-		);
-		add_meta_box(
-			'upcoming-meetings',
-			'Upcoming Meetings',
-			array( $this, 'render_meta_upcoming' ),
-			'meeting',
-			'normal',
-			'high'
-		);
-	}
+			$from = DateTime::createFromFormat( 'U', strtotime( '-30 minutes', $now ) );
+			$end  = DateTime::createFromFormat( 'U', strtotime( '+2 month', $now ) );
+			if ( $meeting->end_date ) {
+				$end = DateTime::createFromFormat( 'Y-m-d', $meeting->end_date );
+			}
+			$max         = 12;
+			$occurrences = array();
+			do {
+				$next = $this->get_next_occurrence( $meeting, $from->format( 'Y-m-d H:i:s P' ) );
+				if ( $next ) {
+					$from = new DateTime( "{$next} {$meeting->time}" );
+					if ( $from <= $end ) {
+						$occurrences[] = $next;
+					}
+				}
+			} while ( --$max > 0 && $next && $from && $from < $end && $meeting->recurring );
 
-	function render_meta_boxes( $post ) {
-		wp_enqueue_script( 'jquery-ui-datepicker' );
-		wp_enqueue_style( 'jquery-ui-style', 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css', true);
-
-		$meta       = get_post_custom( $post->ID );
-		$team       = isset( $meta['team'][0] ) ? $meta['team'][0] : '';
-		$start      = isset( $meta['start_date'][0] ) ? $meta['start_date'][0] : '';
-		$end        = isset( $meta['end_date'][0] ) ? $meta['end_date'][0] : '';
-		$time       = isset( $meta['time'][0] ) ? $meta['time'][0] : '';
-		$recurring  = isset( $meta['recurring'][0] ) ? $meta['recurring'][0] : '';
-		if ( '1' === $recurring ) {
-			$recurring = 'weekly';
+			return $occurrences;
 		}
-		$occurrence = isset( $meta['occurrence'][0] ) ? unserialize( $meta['occurrence'][0] ) : array();
-		$link       = isset( $meta['link'][0] ) ? $meta['link'][0] : '';
-		$location   = isset( $meta['location'][0] ) ? $meta['location'][0] : '';
-		wp_nonce_field( 'save_meeting_meta_'.$post->ID , 'meeting_nonce' );
-		?>
+
+		public function add_meta_boxes() {
+			add_meta_box(
+				'meeting-info',
+				'Meeting Info',
+				array( $this, 'render_meta_boxes' ),
+				'meeting',
+				'normal',
+				'high'
+			);
+			add_meta_box(
+				'upcoming-meetings',
+				'Upcoming Meetings',
+				array( $this, 'render_meta_upcoming' ),
+				'meeting',
+				'normal',
+				'high'
+			);
+		}
+
+		function render_meta_boxes( $post ) {
+			wp_enqueue_script( 'jquery-ui-datepicker' );
+			wp_enqueue_style( 'jquery-ui-style', 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css', true );
+
+			$meta      = get_post_custom( $post->ID );
+			$team      = isset( $meta['team'][0] ) ? $meta['team'][0] : '';
+			$start     = isset( $meta['start_date'][0] ) ? $meta['start_date'][0] : '';
+			$end       = isset( $meta['end_date'][0] ) ? $meta['end_date'][0] : '';
+			$time      = isset( $meta['time'][0] ) ? $meta['time'][0] : '';
+			$recurring = isset( $meta['recurring'][0] ) ? $meta['recurring'][0] : '';
+			if ( '1' === $recurring ) {
+				$recurring = 'weekly';
+			}
+			$occurrence = isset( $meta['occurrence'][0] ) ? unserialize( $meta['occurrence'][0] ) : array();
+			$link       = isset( $meta['link'][0] ) ? $meta['link'][0] : '';
+			$location   = isset( $meta['location'][0] ) ? $meta['location'][0] : '';
+			wp_nonce_field( 'save_meeting_meta_' . $post->ID, 'meeting_nonce' );
+			?>
 
 		<p>
 		<label for="team">
@@ -467,7 +493,7 @@ class Meeting_Post_Type {
 		</label>
 		</p>
 		<p class="recurring">
-		<?php _e( 'Recurring: ', 'wporg' ); ?><br />
+			<?php _e( 'Recurring: ', 'wporg' ); ?><br />
 		<label for="weekly">
 			<input type="radio" name="recurring" value="weekly" id="weekly" class="regular-radio" <?php checked( $recurring, 'weekly' ); ?>>
 			<?php _e( 'Weekly', 'wporg' ); ?>
@@ -530,44 +556,45 @@ class Meeting_Post_Type {
 			}
 		});
 		</script>
-	<?php
-	}
-
-	function render_meta_upcoming( $meeting ) {
-
-		$occurrences = $this->get_future_occurrences( $meeting, null, null );
-		if ( count( $occurrences ) ) {
-			?>
-				<ul>
-			<?php
-
-			foreach ( $occurrences as $occurrence ) {
-				$is_cancelled = $this->is_meeting_cancelled( $meeting->ID, $occurrence );
-				?>
-					<li>
-						<label>
-							<?php printf( __( '%s at %s', 'wporg' ), $occurrence, $meeting->time); ?>
-							<input type="checkbox" class="cancel-meeting" value="<?php echo esc_attr($meeting->ID) . ':' . esc_attr( $occurrence ); ?>" <?php checked( ! $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ); ?> />
-							<span class="meeting-status">
-								<?php if ( $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ) {
-									echo __( 'Cancelled', 'wporg' );
-								} ?>
-							</span>
-						</label>
-					</li>
-				<?php
-			}
-			?>
-				</ul>
-			<?php
-
-		} else {
-			?>
-				<p><?php _e( 'No upcoming meetings.', 'wporg' ); ?></p>
 			<?php
 		}
 
-		?>
+		function render_meta_upcoming( $meeting ) {
+			$occurrences = $this->get_future_occurrences( $meeting, null, null );
+			if ( count( $occurrences ) ) {
+				?>
+				<ul>
+				<?php
+
+				foreach ( $occurrences as $occurrence ) {
+					$is_cancelled = $this->is_meeting_cancelled( $meeting->ID, $occurrence );
+					?>
+					<li>
+						<label>
+							<?php printf( __( '%1$s at %2$s', 'wporg' ), $occurrence, $meeting->time ); ?>
+							<input type="checkbox" class="cancel-meeting" value="<?php echo esc_attr( $meeting->ID ) . ':' . esc_attr( $occurrence ); ?>" <?php checked( ! $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ); ?> />
+							<span class="meeting-status">
+								<?php
+								if ( $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ) {
+									echo __( 'Cancelled', 'wporg' );
+								}
+								?>
+							</span>
+						</label>
+					</li>
+					<?php
+				}
+				?>
+				</ul>
+				<?php
+
+			} else {
+				?>
+				<p><?php _e( 'No upcoming meetings.', 'wporg' ); ?></p>
+				<?php
+			}
+
+			?>
 
 		<script>
 			jQuery(document).ready( function($) {
@@ -601,257 +628,267 @@ class Meeting_Post_Type {
 
 			} );
 		</script>
-		<?php
-	}
-
-	function save_meta_boxes( $post_id ) {
-
-		global $post;
-
-		// Verify nonce
-		if ( !isset( $_POST['meeting_nonce'] ) || !wp_verify_nonce( $_POST['meeting_nonce'], 'save_meeting_meta_'.$post_id ) ) {
-			return $post_id;
+			<?php
 		}
 
-		// Check autosave
-		if ( (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) || ( defined('DOING_AJAX') && DOING_AJAX) || isset($_REQUEST['bulk_edit']) ) {
-			return $post_id;
+		function save_meta_boxes( $post_id ) {
+			global $post;
+
+			// Verify nonce
+			if ( ! isset( $_POST['meeting_nonce'] ) || ! wp_verify_nonce( $_POST['meeting_nonce'], 'save_meeting_meta_' . $post_id ) ) {
+				return $post_id;
+			}
+
+			// Check autosave
+			if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || isset( $_REQUEST['bulk_edit'] ) ) {
+				return $post_id;
+			}
+
+			// Don't save for revisions
+			if ( isset( $post->post_type ) && 'revision' === $post->post_type ) {
+				return $post_id;
+			}
+
+			// Check permissions
+			if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+				return $post_id;
+			}
+
+			// Basic validation
+			if ( empty( trim( $_POST['post_title'] ) ) ) {
+				return false;
+			}
+			if ( empty( trim( $_POST['start_date'] ) ) ) {
+				return false;
+			}
+			if ( false === strtotime( $_POST['start_date'] ) ) {
+				return false;
+			}
+			if ( ! empty( trim( $_POST['end_date'] ) ) && false === strtotime( $_POST['end_date'] ) ) {
+				return false;
+			}
+			if ( empty( trim( $_POST['time'] ) ) ) {
+				return false;
+			}
+			if ( false === strtotime( $_POST['time'] ) ) {
+				return false;
+			}
+
+			$meta['team']       = ( isset( $_POST['team'] ) ? esc_textarea( $_POST['team'] ) : '' );
+			$meta['start_date'] = ( isset( $_POST['start_date'] ) ? esc_textarea( $_POST['start_date'] ) : '' );
+			$meta['end_date']   = ( isset( $_POST['end_date'] ) ? esc_textarea( $_POST['end_date'] ) : '' );
+			$meta['time']       = ( isset( $_POST['time'] ) ? esc_textarea( $_POST['time'] ) : '' );
+			$meta['recurring']  = ( isset( $_POST['recurring'] )
+								 && in_array( $_POST['recurring'], array( 'weekly', 'biweekly', 'occurrence', 'monthly' ) )
+								 ? ( $_POST['recurring'] ) : '' );
+			$meta['occurrence'] = ( isset( $_POST['occurrence'] ) && 'occurrence' === $meta['recurring']
+								 && is_array( $_POST['occurrence'] )
+								 ? array_map( 'intval', $_POST['occurrence'] ) : array() );
+			$meta['link']       = ( isset( $_POST['link'] ) ? esc_url( $_POST['link'] ) : '' );
+			$meta['location']   = ( isset( $_POST['location'] ) ? esc_textarea( $_POST['location'] ) : '' );
+
+			foreach ( $meta as $key => $value ) {
+				update_post_meta( $post->ID, $key, $value );
+			}
 		}
 
-		// Don't save for revisions
-		if ( isset( $post->post_type ) && 'revision' === $post->post_type ) {
-			return $post_id;
+		/**
+		 * Adds "Edit Meetings" item after "Add New" menu.
+		 *
+		 * @param \WP_Admin_Bar $wp_admin_bar The admin bar instance.
+		 */
+		public function add_edit_meetings_item_to_admin_bar( $wp_admin_bar ) {
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return;
+			}
+
+			if ( is_admin() || ! is_post_type_archive( 'meeting' ) ) {
+				return;
+			}
+
+			$wp_admin_bar->add_menu(
+				array(
+					'id'    => 'edit-meetings',
+					'title' => '<span class="ab-icon"></span>' . __( 'Edit Meetings', 'wporg' ),
+					'href'  => admin_url( 'edit.php?post_type=meeting' ),
+				)
+			);
 		}
 
-		// Check permissions
-		if ( !current_user_can( 'edit_post', $post->ID ) ) {
-			return $post_id;
-		}
+		/**
+		 * Adds icon for the "Edit Meetings" item.
+		 */
+		public function add_edit_meetings_icon_to_admin_bar() {
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return;
+			}
 
-		// Basic validation
-		if ( empty( trim( $_POST['post_title'] ) ) )
-			return false;
-		if ( empty( trim( $_POST['start_date'] ) ) )
-			return false;
-		if ( false === strtotime( $_POST['start_date'] ) )
-			return false;
-		if ( !empty( trim( $_POST['end_date'] ) ) && false === strtotime( $_POST['end_date'] ) )
-			return false;
-		if ( empty( trim( $_POST['time'] ) ) )
-			return false;
-		if ( false === strtotime( $_POST['time'] ) )
-			return false;
-
-		$meta['team']        = ( isset( $_POST['team'] ) ? esc_textarea( $_POST['team'] ) : '' );
-		$meta['start_date']  = ( isset( $_POST['start_date'] ) ? esc_textarea( $_POST['start_date'] ) : '' );
-		$meta['end_date']    = ( isset( $_POST['end_date'] ) ? esc_textarea( $_POST['end_date'] ) : '' );
-		$meta['time']        = ( isset( $_POST['time'] ) ? esc_textarea( $_POST['time'] ) : '' );
-		$meta['recurring']   = ( isset( $_POST['recurring'] )
-		                         && in_array( $_POST['recurring'], array( 'weekly', 'biweekly', 'occurrence', 'monthly' ) )
-		                         ? ( $_POST['recurring'] ) : '' );
-		$meta['occurrence']  = ( isset( $_POST['occurrence'] ) && 'occurrence' === $meta['recurring']
-		                         && is_array( $_POST['occurrence'] )
-		                         ? array_map( 'intval', $_POST['occurrence'] ) : array() );
-		$meta['link']        = ( isset( $_POST['link'] ) ? esc_url( $_POST['link'] ) : '' );
-		$meta['location']    = ( isset( $_POST['location'] ) ? esc_textarea( $_POST['location'] ) : '' );
-
-		foreach ( $meta as $key => $value ) {
-			update_post_meta( $post->ID, $key, $value );
-		}
-	}
-
-	/**
-	 * Adds "Edit Meetings" item after "Add New" menu.
-	 *
-	 * @param \WP_Admin_Bar $wp_admin_bar The admin bar instance.
-	 */
-	public function add_edit_meetings_item_to_admin_bar( $wp_admin_bar ) {
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return;
-		}
-
-		if ( is_admin() || ! is_post_type_archive( 'meeting' ) ) {
-			return;
-		}
-
-		$wp_admin_bar->add_menu(
-			array(
-				'id'    => 'edit-meetings',
-				'title' => '<span class="ab-icon"></span>' . __( 'Edit Meetings', 'wporg' ),
-				'href'  => admin_url( 'edit.php?post_type=meeting' ),
-			)
-		);
-	}
-
-	/**
-	 * Adds icon for the "Edit Meetings" item.
-	 */
-	public function add_edit_meetings_icon_to_admin_bar() {
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return;
-		}
-
-		wp_add_inline_style( 'admin-bar', '
+			wp_add_inline_style(
+				'admin-bar',
+				'
 			#wpadminbar #wp-admin-bar-edit-meetings .ab-icon:before {
 				content: "\f145";
 				top: 2px;
 			}
-		' );
-	}
-
-	/**
-	 * Renders meeting information with the next meeting time based on user's local timezone. Used in Make homepage.
-	 */
-	public function meeting_time_shortcode( $attr, $content = '' ) {
-
-		$attr = shortcode_atts( array(
-			'team' => null,
-			'limit' => 1,
-			'before' => __( 'Next meeting: ', 'wporg' ),
-			'titletag' => 'strong',
-			'more' => true,
-		), $attr );
-
-		if ( empty( $attr['team'] ) ) {
-			return '';
+		'
+			);
 		}
 
-		if ( $attr['team'] === 'Documentation' ) {
-			$attr['team'] = 'Docs';
-		}
+		/**
+		 * Renders meeting information with the next meeting time based on user's local timezone. Used in Make homepage.
+		 */
+		public function meeting_time_shortcode( $attr, $content = '' ) {
+			$attr = shortcode_atts(
+				array(
+					'team'     => null,
+					'limit'    => 1,
+					'before'   => __( 'Next meeting: ', 'wporg' ),
+					'titletag' => 'strong',
+					'more'     => true,
+				),
+				$attr
+			);
 
-		if ( ! has_action( 'wp_footer', array( $this, 'time_conversion_script' ) ) ) {
-			add_action( 'wp_footer', array( $this, 'time_conversion_script' ), 999 );
-		}
+			if ( empty( $attr['team'] ) ) {
+				return '';
+			}
 
-		// If we're on a network, assume the calendar exists on the main site
-		if ( function_exists( 'switch_to_blog' ) ) {
-			switch_to_blog( get_main_site_id() );
-		}
+			if ( $attr['team'] === 'Documentation' ) {
+				$attr['team'] = 'Docs';
+			}
 
-		$query = new WP_Query(
-			array(
-				'post_type' => 'meeting',
-				'nopaging'  => true,
-				'meta_query' => array(
-					'relation' => 'AND',
-					array(
-						'key'     => 'team',
-						'value'   => $attr['team'],
-						'compare' => 'EQUALS',
+			if ( ! has_action( 'wp_footer', array( $this, 'time_conversion_script' ) ) ) {
+				add_action( 'wp_footer', array( $this, 'time_conversion_script' ), 999 );
+			}
+
+			// If we're on a network, assume the calendar exists on the main site
+			if ( function_exists( 'switch_to_blog' ) ) {
+				switch_to_blog( get_main_site_id() );
+			}
+
+			$query = new WP_Query(
+				array(
+					'post_type'  => 'meeting',
+					'nopaging'   => true,
+					'meta_query' => array(
+						'relation' => 'AND',
+						array(
+							'key'     => 'team',
+							'value'   => $attr['team'],
+							'compare' => 'EQUALS',
+						),
+						$this->meeting_meta_query(),
 					),
-					$this->meeting_meta_query()
 				)
-			)
-		);
+			);
 
-		$limit = $attr['limit'] > 0 ? $attr['limit'] : count( $query->posts );
+			$limit = $attr['limit'] > 0 ? $attr['limit'] : count( $query->posts );
 
-		$out = '';
-		foreach ( array_slice( $query->posts, 0, $limit ) as $post ) {
-			$next_meeting_datestring = $post->next_date;
-			$utc_time = strftime( '%H:%M:%S', strtotime( $post->time ) );
-			$next_meeting_iso        = $next_meeting_datestring . 'T' . $utc_time . '+00:00';
-			$next_meeting_timestamp = strtotime( $next_meeting_datestring . ' '. $utc_time );
-			$next_meeting_display = strftime( '%c %Z', $next_meeting_timestamp );
+			$out = '';
+			foreach ( array_slice( $query->posts, 0, $limit ) as $post ) {
+				$next_meeting_datestring = $post->next_date;
+				$utc_time                = strftime( '%H:%M:%S', strtotime( $post->time ) );
+				$next_meeting_iso        = $next_meeting_datestring . 'T' . $utc_time . '+00:00';
+				$next_meeting_timestamp  = strtotime( $next_meeting_datestring . ' ' . $utc_time );
+				$next_meeting_display    = strftime( '%c %Z', $next_meeting_timestamp );
 
-			$slack_channel = null;
-			if ( $post->location && preg_match( '/^#([-\w]+)$/', trim( $post->location ), $match ) ) {
-				$slack_channel = sanitize_title( $match[1] );
-			}
+				$slack_channel = null;
+				if ( $post->location && preg_match( '/^#([-\w]+)$/', trim( $post->location ), $match ) ) {
+					$slack_channel = sanitize_title( $match[1] );
+				}
 
-			$cancelled = $this->is_meeting_cancelled( $post->ID, $post->next_date );
+				$cancelled = $this->is_meeting_cancelled( $post->ID, $post->next_date );
 
-			$out .= '<p class="wporg-meeting-shortcode' . ( $cancelled ? ' meeting-cancelled' : '') . '">';
-			$out .= '<span class="wporg-meeting-detail">';
+				$out .= '<p class="wporg-meeting-shortcode' . ( $cancelled ? ' meeting-cancelled' : '' ) . '">';
+				$out .= '<span class="wporg-meeting-detail">';
 
-			$out .= esc_html( $attr['before'] );
-			$out .= '<strong class="meeting-title">' . esc_html( $post->post_title ) . '</strong>';
-			$display_more = $query->found_posts - intval( $limit );
-			if ( $display_more > 0 ) {
-				$out .= ' <a title="Click to view all meetings for this team" href="/meetings/#' . esc_attr( strtolower( $attr['team'] ) ) . '">' . sprintf( __( '(+%s more)'), $display_more ) . '</a>';
-			}
-			$out .= '<br/>';
-			$out .= '<time class="date" date-time="' . esc_attr( $next_meeting_iso ) . '" title="' . esc_attr( $next_meeting_iso ) . '">' . $next_meeting_display . '</time> ';
-			$out .= sprintf( esc_html__( '(%s from now)' ), human_time_diff( $next_meeting_timestamp, current_time('timestamp') ) );
-			if ( $post->location && $slack_channel ) {
-				$out .= ' ' . sprintf( wp_kses( __('at <a href="%s">%s</a> on Slack'), array(  'a' => array( 'href' => array() ) ) ), 'https://wordpress.slack.com/messages/' . $slack_channel,   $post->location );
-			}
-			$out .= '</span>';
+				$out         .= esc_html( $attr['before'] );
+				$out         .= '<strong class="meeting-title">' . esc_html( $post->post_title ) . '</strong>';
+				$display_more = $query->found_posts - intval( $limit );
+				if ( $display_more > 0 ) {
+					$out .= ' <a title="Click to view all meetings for this team" href="/meetings/#' . esc_attr( strtolower( $attr['team'] ) ) . '">' . sprintf( __( '(+%s more)' ), $display_more ) . '</a>';
+				}
+				$out .= '<br/>';
+				$out .= '<time class="date" date-time="' . esc_attr( $next_meeting_iso ) . '" title="' . esc_attr( $next_meeting_iso ) . '">' . $next_meeting_display . '</time> ';
+				$out .= sprintf( esc_html__( '(%s from now)' ), human_time_diff( $next_meeting_timestamp, current_time( 'timestamp' ) ) );
+				if ( $post->location && $slack_channel ) {
+					$out .= ' ' . sprintf( wp_kses( __( 'at <a href="%1$s">%2$s</a> on Slack' ), array( 'a' => array( 'href' => array() ) ) ), 'https://wordpress.slack.com/messages/' . $slack_channel, $post->location );
+				}
+				$out .= '</span>';
 
-			if ( $cancelled ) {
-				$out .= '<br>';
-				$future_occurrences = $this->get_future_occurrences( $post, null, array() );
-				$next_meeting = null;
-				foreach ( $future_occurrences as $occurrence ) {
-					if ( !$this->is_meeting_cancelled( $post->ID, $occurrence )
+				if ( $cancelled ) {
+					$out               .= '<br>';
+					$future_occurrences = $this->get_future_occurrences( $post, null, array() );
+					$next_meeting       = null;
+					foreach ( $future_occurrences as $occurrence ) {
+						if ( ! $this->is_meeting_cancelled( $post->ID, $occurrence )
 							&& $occurrence > $post->next_date ) {
-						$next_meeting = $occurrence;
-						break;
+							$next_meeting = $occurrence;
+							break;
+						}
+					}
+					if ( $next_meeting ) {
+						$out .= '<i>' . sprintf( esc_html__( 'This event is cancelled. The next meeting is scheduled for %s.', 'wporg' ), $next_meeting ) . '</i>';
+					} else {
+						$out .= '<i>' . esc_html__( 'This event is cancelled.', 'wporg' ) . '</i>';
 					}
 				}
-				if ( $next_meeting ) {
-					$out .= '<i>' . sprintf( esc_html__( 'This event is cancelled. The next meeting is scheduled for %s.', 'wporg' ), $next_meeting ) . '</i>';
-				} else {
-					$out .= '<i>' . esc_html__( 'This event is cancelled.', 'wporg' ) . '</i>';
-				}
+				$out .= '</p>';
 			}
-			$out .= '</p>';
+
+			if ( function_exists( 'restore_current_blog' ) ) {
+				restore_current_blog();
+			}
+
+			return $out;
 		}
 
-		if ( function_exists( 'restore_current_blog' ) ) {
-			restore_current_blog();
-		}
-
-		return $out;
-	}
-
-	public function meeting_meta_query() {
-		return array(
-			'relation'=>'OR',
-			// not recurring  AND start_date >= CURDATE() = one-time meeting today or still in future
-			array(
-				'relation' => 'AND',
+		public function meeting_meta_query() {
+			return array(
+				'relation' => 'OR',
+				// not recurring  AND start_date >= CURDATE() = one-time meeting today or still in future
 				array(
-					'key'     => 'recurring',
-					'value'   => array( 'weekly', 'biweekly', 'occurrence', 'monthly', '1' ),
-					'compare' => 'NOT IN',
-				),
-				array(
-					'key'     => 'start_date',
-					'type'    => 'DATE',
-					'compare' => '>=',
-					'value'   => gmdate( 'Y-m-d' ),
-				)
-			),
-			// recurring = 1 AND ( end_date = '' OR end_date > CURDATE() ) = recurring meeting that has no end or has not ended yet
-			array(
-				'relation' => 'AND',
-				array(
-					'key'     => 'recurring',
-					'value'   => array( 'weekly', 'biweekly', 'occurrence', 'monthly', '1' ),
-					'compare' => 'IN',
-				),
-				array(
-					'relation' => 'OR',
+					'relation' => 'AND',
 					array(
-						'key'     => 'end_date',
-						'value'   => '',
-						'compare' => '=',
+						'key'     => 'recurring',
+						'value'   => array( 'weekly', 'biweekly', 'occurrence', 'monthly', '1' ),
+						'compare' => 'NOT IN',
 					),
 					array(
-						'key'     => 'end_date',
+						'key'     => 'start_date',
 						'type'    => 'DATE',
-						'compare' => '>',
+						'compare' => '>=',
 						'value'   => gmdate( 'Y-m-d' ),
-					)
-				)
-			),
-		);
-	}
+					),
+				),
+				// recurring = 1 AND ( end_date = '' OR end_date > CURDATE() ) = recurring meeting that has no end or has not ended yet
+				array(
+					'relation' => 'AND',
+					array(
+						'key'     => 'recurring',
+						'value'   => array( 'weekly', 'biweekly', 'occurrence', 'monthly', '1' ),
+						'compare' => 'IN',
+					),
+					array(
+						'relation' => 'OR',
+						array(
+							'key'     => 'end_date',
+							'value'   => '',
+							'compare' => '=',
+						),
+						array(
+							'key'     => 'end_date',
+							'type'    => 'DATE',
+							'compare' => '>',
+							'value'   => gmdate( 'Y-m-d' ),
+						),
+					),
+				),
+			);
+		}
 
-	public function time_conversion_script() {
-		echo <<<EOF
+		public function time_conversion_script() {
+			echo <<<EOF
 <script type="text/javascript">
 
 	var parse_date = function (text) {
@@ -881,12 +918,11 @@ class Meeting_Post_Type {
 	}
 </script>
 EOF;
+		}
 	}
-}
 
-// fire it up
-Meeting_Post_Type::init();
-
+	// fire it up
+	Meeting_Post_Type::init();
 endif;
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1591,6 +1591,12 @@
       "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
       "dev": true
     },
+    "@sindresorhus/is": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+      "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -1751,6 +1757,15 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -1798,6 +1813,18 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "dev": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "@types/cheerio": {
       "version": "0.22.24",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.24.tgz",
@@ -1825,6 +1852,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -1861,6 +1894,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/mdast": {
       "version": "3.0.3",
@@ -1936,6 +1978,15 @@
       "dev": true,
       "requires": {
         "@types/react": "^16"
+      }
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/source-list-map": {
@@ -2355,6 +2406,202 @@
         "react-dom": "^16.13.1"
       }
     },
+    "@wordpress/env": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-3.0.2.tgz",
+      "integrity": "sha512-AE4FD8z1Tm3Os64vGpLjlbIdPAaUL8PcWKo7cscscaPpyHjF7XXisA8BHdwlNa0wowCdpOZgV8p+mntp/VexwQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "copy-dir": "^1.3.0",
+        "docker-compose": "^0.22.2",
+        "extract-zip": "^1.6.7",
+        "got": "^10.7.0",
+        "inquirer": "^7.1.0",
+        "js-yaml": "^3.13.1",
+        "nodegit": "^0.27.0",
+        "ora": "^4.0.2",
+        "rimraf": "^3.0.2",
+        "terminal-link": "^2.0.0",
+        "yargs": "^14.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "extract-zip": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+          "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.6.2",
+            "debug": "^2.6.9",
+            "mkdirp": "^0.5.4",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "@wordpress/escape-html": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.11.1.tgz",
@@ -2542,6 +2789,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -2680,6 +2933,42 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -3409,10 +3698,32 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "buffer-from": {
@@ -3511,6 +3822,48 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "cacheable-lookup": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+      "dev": true,
+      "requires": {
+        "@types/keyv": "^3.1.1",
+        "keyv": "^4.0.0"
+      }
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+          "dev": true
+        }
       }
     },
     "call-bind": {
@@ -3674,6 +4027,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "check-node-version": {
@@ -3913,6 +4272,27 @@
         "del": "^4.1.1"
       }
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3923,6 +4303,12 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
     },
     "clone-deep": {
       "version": "0.2.4",
@@ -3957,6 +4343,23 @@
         "is-regexp": "^2.0.0"
       }
     },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+          "dev": true
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3986,6 +4389,12 @@
           }
         }
       }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -4113,6 +4522,12 @@
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -4158,6 +4573,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+      "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
       "dev": true
     },
     "core-js": {
@@ -4548,6 +4969,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "deep-extend": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
@@ -4564,6 +4994,21 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true
     },
     "define-properties": {
@@ -4675,6 +5120,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -4689,6 +5140,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "detect-newline": {
@@ -4741,6 +5198,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
+    },
+    "docker-compose": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
+      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
       "dev": true
     },
     "doctrine": {
@@ -4831,6 +5294,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "duplexify": {
@@ -5880,6 +6349,17 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -6059,6 +6539,15 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -6544,6 +7033,17 @@
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -6633,6 +7133,59 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
       "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -6789,6 +7342,46 @@
         "minimist": "^1.2.5"
       }
     },
+    "got": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+      "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^2.0.0",
+        "@szmarczak/http-timer": "^4.0.0",
+        "@types/cacheable-request": "^6.0.1",
+        "cacheable-lookup": "^2.0.0",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^5.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^5.0.0",
+        "lowercase-keys": "^2.0.0",
+        "mimic-response": "^2.1.0",
+        "p-cancelable": "^2.0.0",
+        "p-event": "^4.0.0",
+        "responselike": "^2.0.0",
+        "to-readable-stream": "^2.0.0",
+        "type-fest": "^0.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+          "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -6864,6 +7457,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -7046,6 +7645,12 @@
         }
       }
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
     "http-parser-js": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
@@ -7126,6 +7731,15 @@
       "resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.6.tgz",
       "integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -7284,6 +7898,27 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      }
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -7511,6 +8146,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
     },
     "is-negative-zero": {
@@ -8608,6 +9249,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -8665,6 +9312,15 @@
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
       "dev": true
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -8685,6 +9341,15 @@
       "requires": {
         "array-includes": "^3.1.2",
         "object.assign": "^4.1.2"
+      }
+    },
+    "keyv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "kind-of": {
@@ -8884,6 +9549,12 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -9392,6 +10063,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9641,12 +10318,17 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9685,6 +10367,28 @@
         "randexp": "0.4.6"
       }
     },
+    "needle": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -9702,6 +10406,82 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
+    },
+    "node-gyp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
+      "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^4.4.8",
+        "which": "1"
+      },
+      "dependencies": {
+        "fs-minipass": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -9828,11 +10608,195 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
+      "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "fs-minipass": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
     "node-releases": {
       "version": "1.1.71",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
       "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
       "dev": true
+    },
+    "nodegit": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.27.0.tgz",
+      "integrity": "sha512-E9K4gPjWiA0b3Tx5lfWCzG7Cvodi2idl3V5UD2fZrOrHikIfrN7Fc2kWLtMUqqomyoToYJLeIC8IV7xb1CYRLA==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "got": "^10.7.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.14",
+        "nan": "^2.14.0",
+        "node-gyp": "^4.0.0",
+        "node-pre-gyp": "^0.13.0",
+        "ramda": "^0.25.0",
+        "tar-fs": "^1.16.3"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "tar-fs": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+          "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "dev": true,
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -9883,6 +10847,21 @@
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
       }
+    },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "dev": true,
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
     },
     "npm-package-json-lint": {
       "version": "5.1.0",
@@ -9937,6 +10916,17 @@
         }
       }
     },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "dev": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -9944,6 +10934,18 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -9959,6 +10961,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nwsapi": {
@@ -10153,6 +11161,134 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ora": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.2.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^3.0.0",
+        "mute-stream": "0.0.8",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -10165,11 +11301,42 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+      "dev": true
+    },
     "p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
       "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
+    },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -10200,6 +11367,15 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -11171,6 +12347,12 @@
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
     },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
+      "dev": true
+    },
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
@@ -11821,6 +13003,25 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -11868,6 +13069,12 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11891,6 +13098,15 @@
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
+      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -13635,6 +14851,15 @@
         }
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -13645,6 +14870,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
     },
     "to-fast-properties": {
@@ -13672,6 +14903,12 @@
           }
         }
       }
+    },
+    "to-readable-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+      "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
+      "dev": true
     },
     "to-regex": {
       "version": "3.0.2",
@@ -14016,6 +15253,12 @@
       "requires": {
         "unist-util-is": "^3.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unquote": {
       "version": "1.1.1",
@@ -14628,6 +15871,15 @@
             "repeat-string": "^1.6.1"
           }
         }
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {
@@ -15408,6 +16660,48 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2641,6 +2641,12 @@
           "requires": {
             "type-fest": "^0.8.1"
           }
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+          "dev": true
         }
       }
     },
@@ -2752,6 +2758,101 @@
         "webpack-cli": "^3.3.11",
         "webpack-livereload-plugin": "^2.3.0",
         "webpack-sources": "^2.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+          "dev": true
+        },
+        "puppeteer": {
+          "version": "npm:puppeteer-core@5.5.0",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+          "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "devtools-protocol": "0.0.818844",
+            "extract-zip": "^2.0.0",
+            "https-proxy-agent": "^4.0.0",
+            "node-fetch": "^2.6.1",
+            "pkg-dir": "^4.2.0",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^3.0.2",
+            "tar-fs": "^2.0.0",
+            "unbzip2-stream": "^1.3.3",
+            "ws": "^7.2.3"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@wordpress/stylelint-config": {
@@ -11997,12 +12098,6 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
-    "prettier": {
-      "version": "npm:wp-prettier@2.2.1-beta-1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-      "dev": true
-    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -12196,95 +12291,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "puppeteer": {
-      "version": "npm:puppeteer-core@5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "packages-update": "wp-scripts packages-update",
     "start": "wp-scripts start index=./src/index.js calendar=./src/frontend/index.js",
     "test:e2e": "wp-scripts test-e2e",
-    "test:unit": "wp-scripts test-unit-js"
+    "test:unit": "wp-scripts test-unit-js",
+    "test:unit-php": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/meeting-calendar/phpunit.xml.dist --verbose'",
+    "wp-env": "wp-env"
   },
   "repository": {
     "type": "git",
@@ -29,6 +31,7 @@
   },
   "homepage": "https://github.com/Automattic/meeting-calendar#readme",
   "devDependencies": {
+    "@wordpress/env": "^3.0.2",
     "@wordpress/scripts": "13.0.3"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="meeting-calendar">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 			<exclude>./tests/test-sample.php</exclude>
 		</testsuite>

--- a/plugin.php
+++ b/plugin.php
@@ -18,12 +18,12 @@ namespace WordPressdotorg\Meeting_Calendar;
  * @return string List of meetings in JSON format
  */
 function get_meeting_data( $per_page ) {
-	$date = date( 'Y-m-d', strtotime( 'first day of this month' ) );
+	$date    = date( 'Y-m-d', strtotime( 'first day of this month' ) );
 	$request = new \WP_REST_Request( 'GET', '/wp/v2/meetings/from/' . $date );
-	$request->set_query_params( [ 'per_page' => $per_page ] );
+	$request->set_query_params( array( 'per_page' => $per_page ) );
 	$response = rest_do_request( $request );
-	$server = rest_get_server();
-	$data = $server->response_to_data( $response, false );
+	$server   = rest_get_server();
+	$data     = $server->response_to_data( $response, false );
 	return wp_json_encode( $data );
 }
 
@@ -47,19 +47,19 @@ function render_callback( $attributes, $content ) {
  * Register scripts, styles, and block.
  */
 function register_assets() {
-	$block_deps_path = __DIR__ . '/build/index.asset.php';
+	$block_deps_path    = __DIR__ . '/build/index.asset.php';
 	$frontend_deps_path = __DIR__ . '/build/calendar.asset.php';
 	if ( ! file_exists( $block_deps_path ) || ! file_exists( $frontend_deps_path ) ) {
 		return;
 	}
 
-	$block_info = require $block_deps_path;
+	$block_info    = require $block_deps_path;
 	$frontend_info = require $frontend_deps_path;
 
 	// Register our block script with WordPress.
 	wp_register_script(
 		'wporg-calendar-block-script',
-		plugins_url('build/index.js', __FILE__),
+		plugins_url( 'build/index.js', __FILE__ ),
 		$block_info['dependencies'],
 		$block_info['version'],
 		false
@@ -69,12 +69,12 @@ function register_assets() {
 	wp_register_style(
 		'wporg-calendar-block-style',
 		plugins_url( 'style.css', __FILE__ ),
-		[],
+		array(),
 		$block_info['version']
 	);
 
 	// No frontend scripts in the editor
-	if( ! is_admin() ) {
+	if ( ! is_admin() ) {
 		wp_register_script(
 			'wporg-calendar-script',
 			plugin_dir_url( __FILE__ ) . 'build/calendar.js',
@@ -95,15 +95,15 @@ function register_assets() {
 	register_block_type(
 		'wporg-meeting-calendar/main',
 		array(
-			'editor_script' => 'wporg-calendar-block-script',
-			'editor_style' => 'wporg-calendar-block-style',
-			'script' => 'wporg-calendar-script',
-			'style' => 'wporg-calendar-style',
+			'editor_script'   => 'wporg-calendar-block-script',
+			'editor_style'    => 'wporg-calendar-block-style',
+			'script'          => 'wporg-calendar-script',
+			'style'           => 'wporg-calendar-style',
 			'render_callback' => __NAMESPACE__ . '\render_callback',
 		)
 	);
 }
-add_action('init', __NAMESPACE__ . '\register_assets');
+add_action( 'init', __NAMESPACE__ . '\register_assets' );
 
 /**
  * Conditionally remove the Script/Style assets added through `register_block_type()`.
@@ -120,10 +120,10 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\conditionally_load_assets'
  * Set up the Meetings post type.
  */
 function init() {
-	require_once( __DIR__ . '/includes/wporg-meeting-posttype.php' );
+	require_once __DIR__ . '/includes/wporg-meeting-posttype.php';
 	new \Meeting_Post_Type();
 }
-add_action('plugins_loaded', __NAMESPACE__ . '\init');
+add_action( 'plugins_loaded', __NAMESPACE__ . '\init' );
 
 /**
  * Set up the ICS support.
@@ -131,9 +131,8 @@ add_action('plugins_loaded', __NAMESPACE__ . '\init');
 function ics_init() {
 	require __DIR__ . '/includes/ical-functions.php';
 	require __DIR__ . '/includes/ical-generator-functions.php';
-
 }
-add_action('plugins_loaded', __NAMESPACE__ . '\ics_init');
+add_action( 'plugins_loaded', __NAMESPACE__ . '\ics_init' );
 
 /**
  * First-Install activation hook.
@@ -141,13 +140,13 @@ add_action('plugins_loaded', __NAMESPACE__ . '\ics_init');
  * Creates some sample data, and sets up the Rewrite rules.
  */
 function install( $is_network_wide ) {
-	if ( !$is_network_wide ) {
+	if ( ! $is_network_wide ) {
 		// We need the CPT to be registered to install.
 		init();
 		$meeting_post_type = new \Meeting_Post_Type();
 		$meeting_post_type->getInstance()->register_meeting_post_type();
 
-		require_once( __DIR__ . '/includes/wporg-meeting-install.php' );
+		require_once __DIR__ . '/includes/wporg-meeting-install.php';
 		wporg_meeting_install();
 
 		ics_init();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,18 +5,43 @@
  * @package Meeting_Calendar
  */
 
-namespace WordPressdotorg\Meeting_Calendar\Tests;
+// Require composer dependencies.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
-if ( 'cli' !== php_sapi_name() ) {
-	return;
+// Determine the tests directory (from a WP dev checkout).
+// Try the WP_TESTS_DIR environment variable first.
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+// Next, try the WP_PHPUNIT composer package.
+if ( ! $_tests_dir ) {
+	$_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
 }
+
+// See if we're installed inside an existing WP dev instance.
+if ( ! $_tests_dir ) {
+	$_try_tests_dir = __DIR__ . '/../../../../../tests/phpunit';
+	if ( file_exists( $_try_tests_dir . '/includes/functions.php' ) ) {
+		$_tests_dir = $_try_tests_dir;
+	}
+}
+
+// Fallback.
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
 
 /**
  * Manually load the plugin being tested.
  */
-function manually_load_plugin() {
+function _manually_load_plugin() {
 	require_once dirname( __FILE__ ) . '/../plugin.php';
 	require_once dirname( __FILE__ ) . '/../includes/wporg-meeting-install.php';
 }
 
-tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/fixtures/events-with-cancel.ics
+++ b/tests/fixtures/events-with-cancel.ics
@@ -1,0 +1,24 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Make WordPress//Meeting Events Calendar//EN
+METHOD:PUBLISH
+CALSCALE:GREGORIAN
+X-WR-CALNAME: Making WordPress Meetings
+X-WR-TIMEZONE: UTC
+BEGIN:VEVENT
+UID:%ID%
+DTSTAMP:20200101T140000Z
+DTSTART:20200101T140000Z
+DTEND:20200101T150000Z
+CATEGORIES:WordPress
+ORGANIZER;CN=WordPress Team-A Team:mailto:mail@example.com
+SUMMARY:Team-A: A weekly meeting
+SEQUENCE:0
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+LOCATION:#meta channel on Slack
+DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+RRULE:FREQ=WEEKLY
+EXDATE:%EXDATE%
+END:VEVENT
+END:VCALENDAR

--- a/tests/fixtures/events.ics
+++ b/tests/fixtures/events.ics
@@ -1,0 +1,53 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Make WordPress//Meeting Events Calendar//EN
+METHOD:PUBLISH
+CALSCALE:GREGORIAN
+X-WR-CALNAME: Making WordPress Meetings
+X-WR-TIMEZONE: UTC
+BEGIN:VEVENT
+UID:%ID1%
+DTSTAMP:20200101T140000Z
+DTSTART:20200101T140000Z
+DTEND:20200101T150000Z
+CATEGORIES:WordPress
+ORGANIZER;CN=WordPress Team-A Team:mailto:mail@example.com
+SUMMARY:Team-A: A weekly meeting
+SEQUENCE:0
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+LOCATION:#meta channel on Slack
+DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+RRULE:FREQ=WEEKLY
+END:VEVENT
+BEGIN:VEVENT
+UID:%ID2%
+DTSTAMP:20200101T150000Z
+DTSTART:20200101T150000Z
+DTEND:20200101T160000Z
+CATEGORIES:WordPress
+ORGANIZER;CN=WordPress Team-B Team:mailto:mail@example.com
+SUMMARY:Team-B: A monthly meeting
+SEQUENCE:0
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+LOCATION:#meta channel on Slack
+DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+RRULE:FREQ=MONTHLY
+END:VEVENT
+BEGIN:VEVENT
+UID:%ID3%
+DTSTAMP:20200101T160000Z
+DTSTART:20200101T160000Z
+DTEND:20200101T170000Z
+CATEGORIES:WordPress
+ORGANIZER;CN=WordPress Team-C Team:mailto:mail@example.com
+SUMMARY:Team-C: Third Wednesday of each month
+SEQUENCE:0
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+LOCATION:#meta channel on Slack
+DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+RRULE:FREQ=MONTHLY;BYDAY=3WE
+END:VEVENT
+END:VCALENDAR

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -18,7 +18,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 
 		// Initialize a REST server
 		global $wp_rest_server;
-		$this->server = $wp_rest_server = new \WP_REST_Server;
+		$this->server = $wp_rest_server = new \WP_REST_Server();
 		do_action( 'rest_api_init' );
 
 		// Install test data
@@ -27,7 +27,6 @@ class MeetingAPITest extends WP_UnitTestCase {
 		// Make sure the meta keys are registered - setUp/tearDown nukes these
 		Meeting_Post_Type::getInstance()->register_meta();
 		Meeting_Post_Type::getInstance()->register_rest_routes();
-
 	}
 
 
@@ -51,27 +50,27 @@ class MeetingAPITest extends WP_UnitTestCase {
 	}
 
 	public function test_get_meetings() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meeting' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meeting' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 3, count( $response->get_data() ) );
 	}
 
 	public function test_meeting_weekly() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meeting/' . $this->meeting_ids[0] );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meeting/' . $this->meeting_ids[0] );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meeting = $response->get_data();
 
 		// Make sure the postmeta is all present
-		$this->assertEquals( 'meeting',       $meeting['type'] );
-		$this->assertEquals( 'Team-A',        $meeting['meta']['team'] );
-		$this->assertEquals( '2020-01-01',    $meeting['meta']['start_date'] );
-		$this->assertEquals( '',              $meeting['meta']['end_date'] );
-		$this->assertEquals( '14:00:00',      $meeting['meta']['time'] );
-		$this->assertEquals( 'weekly',        $meeting['meta']['recurring'] );
+		$this->assertEquals( 'meeting', $meeting['type'] );
+		$this->assertEquals( 'Team-A', $meeting['meta']['team'] );
+		$this->assertEquals( '2020-01-01', $meeting['meta']['start_date'] );
+		$this->assertEquals( '', $meeting['meta']['end_date'] );
+		$this->assertEquals( '14:00:00', $meeting['meta']['time'] );
+		$this->assertEquals( 'weekly', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
-		$this->assertEquals( array(),         $meeting['meta']['occurrence'] );
+		$this->assertEquals( array(), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
 		$this->assertGreaterThanOrEqual( 4, count( $meeting['future_occurrences'] ) );
@@ -104,20 +103,20 @@ class MeetingAPITest extends WP_UnitTestCase {
 	}
 
 	public function test_meeting_monthly() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meeting/' . $this->meeting_ids[1] );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meeting/' . $this->meeting_ids[1] );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meeting = $response->get_data();
 
 		// Make sure the postmeta is all present
-		$this->assertEquals( 'meeting',       $meeting['type'] );
-		$this->assertEquals( 'Team-B',        $meeting['meta']['team'] );
-		$this->assertEquals( '2020-01-01',    $meeting['meta']['start_date'] );
-		$this->assertEquals( '',              $meeting['meta']['end_date'] );
-		$this->assertEquals( '15:00:00',      $meeting['meta']['time'] );
-		$this->assertEquals( 'monthly',       $meeting['meta']['recurring'] );
+		$this->assertEquals( 'meeting', $meeting['type'] );
+		$this->assertEquals( 'Team-B', $meeting['meta']['team'] );
+		$this->assertEquals( '2020-01-01', $meeting['meta']['start_date'] );
+		$this->assertEquals( '', $meeting['meta']['end_date'] );
+		$this->assertEquals( '15:00:00', $meeting['meta']['time'] );
+		$this->assertEquals( 'monthly', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
-		$this->assertEquals( array(),         $meeting['meta']['occurrence'] );
+		$this->assertEquals( array(), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
 		$this->assertEquals( 2, count( $meeting['future_occurrences'] ) );
@@ -147,20 +146,20 @@ class MeetingAPITest extends WP_UnitTestCase {
 	}
 
 	public function test_meeting_third_wednesday() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meeting/' . $this->meeting_ids[2] );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meeting/' . $this->meeting_ids[2] );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meeting = $response->get_data();
 
 		// Make sure the postmeta is all present
-		$this->assertEquals( 'meeting',       $meeting['type'] );
-		$this->assertEquals( 'Team-C',        $meeting['meta']['team'] );
-		$this->assertEquals( '2020-01-01',    $meeting['meta']['start_date'] );
-		$this->assertEquals( '',              $meeting['meta']['end_date'] );
-		$this->assertEquals( '16:00:00',      $meeting['meta']['time'] );
-		$this->assertEquals( 'occurrence',    $meeting['meta']['recurring'] );
+		$this->assertEquals( 'meeting', $meeting['type'] );
+		$this->assertEquals( 'Team-C', $meeting['meta']['team'] );
+		$this->assertEquals( '2020-01-01', $meeting['meta']['start_date'] );
+		$this->assertEquals( '', $meeting['meta']['end_date'] );
+		$this->assertEquals( '16:00:00', $meeting['meta']['time'] );
+		$this->assertEquals( 'occurrence', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
-		$this->assertEquals( array(3),        $meeting['meta']['occurrence'] );
+		$this->assertEquals( array( 3 ), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
 		$this->assertEquals( 2, count( $meeting['future_occurrences'] ) );
@@ -192,213 +191,213 @@ class MeetingAPITest extends WP_UnitTestCase {
 	}
 
 	public function _january_meetings() {
-		return array (
-		  0 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-01-01',
-		    'date' => '2020-01-01',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-01-01T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  1 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[1],
-		    'instance_id' => $this->meeting_ids[1] . ':2020-01-01',
-		    'date' => '2020-01-01',
-		    'time' => '15:00:00',
-		    'datetime' => '2020-01-01T15:00:00+00:00',
-		    'team' => 'Team-B',
-		    'link' => 'wordpress.org',
-		    'title' => 'A monthly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'monthly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  2 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-01-08',
-		    'date' => '2020-01-08',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-01-08T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  3 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-01-15',
-		    'date' => '2020-01-15',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-01-15T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  4 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[2],
-		    'instance_id' => $this->meeting_ids[2] . ':2020-01-15',
-		    'date' => '2020-01-15',
-		    'time' => '16:00:00',
-		    'datetime' => '2020-01-15T16:00:00+00:00',
-		    'team' => 'Team-C',
-		    'link' => 'wordpress.org',
-		    'title' => 'Third Wednesday of each month',
-		    'location' => '#meta',
-		    'recurring' => 'occurrence',
-		    'occurrence' => 
-		    array (
-		      0 => 3,
-		    ),
-		    'status' => 'active',
-		  ),
-		  5 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-01-22',
-		    'date' => '2020-01-22',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-01-22T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  6 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-01-29',
-		    'date' => '2020-01-29',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-01-29T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  7 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[1],
-		    'instance_id' => $this->meeting_ids[1] . ':2020-02-01',
-		    'date' => '2020-02-01',
-		    'time' => '15:00:00',
-		    'datetime' => '2020-02-01T15:00:00+00:00',
-		    'team' => 'Team-B',
-		    'link' => 'wordpress.org',
-		    'title' => 'A monthly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'monthly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  8 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-02-05',
-		    'date' => '2020-02-05',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-02-05T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  9 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-02-12',
-		    'date' => '2020-02-12',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-02-12T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  10 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-02-19',
-		    'date' => '2020-02-19',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-02-19T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
-		  11 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[2],
-		    'instance_id' => $this->meeting_ids[2] . ':2020-02-19',
-		    'date' => '2020-02-19',
-		    'time' => '16:00:00',
-		    'datetime' => '2020-02-19T16:00:00+00:00',
-		    'team' => 'Team-C',
-		    'link' => 'wordpress.org',
-		    'title' => 'Third Wednesday of each month',
-		    'location' => '#meta',
-		    'recurring' => 'occurrence',
-		    'occurrence' => 
-		    array (
-		      0 => 3,
-		    ),
-		    'status' => 'active',
-		  ),
-		  12 => 
-		  array (
-		    'meeting_id' => $this->meeting_ids[0],
-		    'instance_id' => $this->meeting_ids[0] . ':2020-02-26',
-		    'date' => '2020-02-26',
-		    'time' => '14:00:00',
-		    'datetime' => '2020-02-26T14:00:00+00:00',
-		    'team' => 'Team-A',
-		    'link' => 'wordpress.org',
-		    'title' => 'A weekly meeting',
-		    'location' => '#meta',
-		    'recurring' => 'weekly',
-		    'occurrence' => '',
-		    'status' => 'active',
-		  ),
+		return array(
+			0  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-01-01',
+				'date'        => '2020-01-01',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-01-01T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			1  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[1],
+				'instance_id' => $this->meeting_ids[1] . ':2020-01-01',
+				'date'        => '2020-01-01',
+				'time'        => '15:00:00',
+				'datetime'    => '2020-01-01T15:00:00+00:00',
+				'team'        => 'Team-B',
+				'link'        => 'wordpress.org',
+				'title'       => 'A monthly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'monthly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			2  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-01-08',
+				'date'        => '2020-01-08',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-01-08T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			3  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-01-15',
+				'date'        => '2020-01-15',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-01-15T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			4  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[2],
+				'instance_id' => $this->meeting_ids[2] . ':2020-01-15',
+				'date'        => '2020-01-15',
+				'time'        => '16:00:00',
+				'datetime'    => '2020-01-15T16:00:00+00:00',
+				'team'        => 'Team-C',
+				'link'        => 'wordpress.org',
+				'title'       => 'Third Wednesday of each month',
+				'location'    => '#meta',
+				'recurring'   => 'occurrence',
+				'occurrence'  =>
+				array(
+					0 => 3,
+				),
+				'status'      => 'active',
+			),
+			5  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-01-22',
+				'date'        => '2020-01-22',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-01-22T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			6  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-01-29',
+				'date'        => '2020-01-29',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-01-29T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			7  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[1],
+				'instance_id' => $this->meeting_ids[1] . ':2020-02-01',
+				'date'        => '2020-02-01',
+				'time'        => '15:00:00',
+				'datetime'    => '2020-02-01T15:00:00+00:00',
+				'team'        => 'Team-B',
+				'link'        => 'wordpress.org',
+				'title'       => 'A monthly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'monthly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			8  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-02-05',
+				'date'        => '2020-02-05',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-02-05T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			9  =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-02-12',
+				'date'        => '2020-02-12',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-02-12T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			10 =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-02-19',
+				'date'        => '2020-02-19',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-02-19T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
+			11 =>
+			array(
+				'meeting_id'  => $this->meeting_ids[2],
+				'instance_id' => $this->meeting_ids[2] . ':2020-02-19',
+				'date'        => '2020-02-19',
+				'time'        => '16:00:00',
+				'datetime'    => '2020-02-19T16:00:00+00:00',
+				'team'        => 'Team-C',
+				'link'        => 'wordpress.org',
+				'title'       => 'Third Wednesday of each month',
+				'location'    => '#meta',
+				'recurring'   => 'occurrence',
+				'occurrence'  =>
+				array(
+					0 => 3,
+				),
+				'status'      => 'active',
+			),
+			12 =>
+			array(
+				'meeting_id'  => $this->meeting_ids[0],
+				'instance_id' => $this->meeting_ids[0] . ':2020-02-26',
+				'date'        => '2020-02-26',
+				'time'        => '14:00:00',
+				'datetime'    => '2020-02-26T14:00:00+00:00',
+				'team'        => 'Team-A',
+				'link'        => 'wordpress.org',
+				'title'       => 'A weekly meeting',
+				'location'    => '#meta',
+				'recurring'   => 'weekly',
+				'occurrence'  => '',
+				'status'      => 'active',
+			),
 		);
 	}
 
 	public function test_meetings_january_2020() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meetings = $response->get_data();
@@ -407,66 +406,63 @@ class MeetingAPITest extends WP_UnitTestCase {
 	}
 
 	public function test_meetings_february_2020() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-02-01' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-02-01' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meetings = $response->get_data();
 
-		$expected_datetimes = array (
-		  0 => '2020-02-01T15:00:00+00:00',
-		  1 => '2020-02-05T14:00:00+00:00',
-		  2 => '2020-02-12T14:00:00+00:00',
-		  3 => '2020-02-19T14:00:00+00:00',
-		  4 => '2020-02-19T16:00:00+00:00',
-		  5 => '2020-02-26T14:00:00+00:00',
-		  6 => '2020-03-01T15:00:00+00:00',
-		  7 => '2020-03-04T14:00:00+00:00',
-		  8 => '2020-03-11T14:00:00+00:00',
-		  9 => '2020-03-18T14:00:00+00:00',
-		  10 => '2020-03-18T16:00:00+00:00',
-		  11 => '2020-03-25T14:00:00+00:00',
+		$expected_datetimes = array(
+			0  => '2020-02-01T15:00:00+00:00',
+			1  => '2020-02-05T14:00:00+00:00',
+			2  => '2020-02-12T14:00:00+00:00',
+			3  => '2020-02-19T14:00:00+00:00',
+			4  => '2020-02-19T16:00:00+00:00',
+			5  => '2020-02-26T14:00:00+00:00',
+			6  => '2020-03-01T15:00:00+00:00',
+			7  => '2020-03-04T14:00:00+00:00',
+			8  => '2020-03-11T14:00:00+00:00',
+			9  => '2020-03-18T14:00:00+00:00',
+			10 => '2020-03-18T16:00:00+00:00',
+			11 => '2020-03-25T14:00:00+00:00',
 		);
 		$this->assertEquals( $expected_datetimes, wp_list_pluck( $meetings, 'datetime' ) );
 
-		$expected_teams = array (
-		  0 => 'Team-B',
-		  1 => 'Team-A',
-		  2 => 'Team-A',
-		  3 => 'Team-A',
-		  4 => 'Team-C',
-		  5 => 'Team-A',
-		  6 => 'Team-B',
-		  7 => 'Team-A',
-		  8 => 'Team-A',
-		  9 => 'Team-A',
-		  10 => 'Team-C',
-		  11 => 'Team-A',
+		$expected_teams = array(
+			0  => 'Team-B',
+			1  => 'Team-A',
+			2  => 'Team-A',
+			3  => 'Team-A',
+			4  => 'Team-C',
+			5  => 'Team-A',
+			6  => 'Team-B',
+			7  => 'Team-A',
+			8  => 'Team-A',
+			9  => 'Team-A',
+			10 => 'Team-C',
+			11 => 'Team-A',
 		);
 		$this->assertEquals( $expected_teams, wp_list_pluck( $meetings, 'team' ) );
-
 	}
 
 	public function test_cancel_meeting_permissions_noauth() {
-
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
+		$request  = new WP_REST_Request( 'PUT', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
 	public function test_cancel_meeting_permissions_valid() {
-
 		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $user_id );
 
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
+		$request  = new WP_REST_Request( 'PUT', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
@@ -476,27 +472,27 @@ class MeetingAPITest extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		// Cancel the meeting on 2020-01-15
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
 		// The feed should show that one meeting as cancelled
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meetings = $response->get_data();
 
-		$january_meetings = $this->_january_meetings();
+		$january_meetings              = $this->_january_meetings();
 		$january_meetings[3]['status'] = 'cancelled';
 		$this->assertEquals( $january_meetings, $meetings );
 
 		// Now uncancel it
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
+		$request  = new WP_REST_Request( 'PUT', '/wp/v2/meetings/' . $this->meeting_ids[0] . ':2020-01-15' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
 		// The feed should be as before
-		$request = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/meetings/from/2020-01-01' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$meetings = $response->get_data();

--- a/tests/test-ical.php
+++ b/tests/test-ical.php
@@ -29,6 +29,20 @@ class MeetingiCalTest extends WP_UnitTestCase {
 		Meeting_Post_Type::getInstance()->register_meta();
 	}
 
+	public function test_get_recurring_strings() {
+		// 2020-01-01 is a Sunday.
+		$freq = get_frequencies_by_day( array( 1, 3 ), '2019-09-15' );
+		$this->assertEquals( 'MONTHLY;BYDAY=1SU,3SU', $freq );
+
+		// 2020-01-01 is a Wednesday.
+		$freq = get_frequencies_by_day( array( 3 ), '2020-01-01' );
+		$this->assertEquals( 'MONTHLY;BYDAY=3WE', $freq );
+
+		// 2025-03-14 is a Friday.
+		$freq = get_frequencies_by_day( array( 4 ), '2025-03-14' );
+		$this->assertEquals( 'MONTHLY;BYDAY=4FR', $freq );
+	}
+
 	public function test_get_ical() {
 		$posts = WordPressdotorg\Meeting_Calendar\ICS\get_meeting_posts();
 		Meeting_Post_Type::getInstance()->meeting_set_next_meeting(

--- a/tests/test-meetingposttype.php
+++ b/tests/test-meetingposttype.php
@@ -26,51 +26,53 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 	function test_single_meeting() {
 		// See https://github.com/Automattic/meeting-calendar/issues/34
 
-		$meeting_id = $this->factory->post->create( array(
-			'post_title' => __( 'A single meeting', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-A',
-				'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
-				'end_date'   => '',
-				'time'       => '01:00',
-				'recurring'  => '',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_id = $this->factory->post->create(
+			array(
+				'post_title'  => __( 'A single meeting', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-A',
+					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'end_date'   => '',
+					'time'       => '01:00',
+					'recurring'  => '',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
-
-		$meetings = $this->mpt->get_occurrences_for_period(null);
-		$found = 0;
+		$meetings = $this->mpt->get_occurrences_for_period( null );
+		$found    = 0;
 		foreach ( $meetings as $meeting ) {
-			if ( $meeting['meeting_id'] === $meeting_id )
+			if ( $meeting['meeting_id'] === $meeting_id ) {
 				++ $found;
+			}
 		}
 
 		$this->assertEquals( 1, $found, 'There should be exactly one instance of a single meeting.' );
 	}
 
 	function test_invalid_time() {
-
-		$meeting_id = $this->factory->post->create( array(
-			'post_title' => __( 'A meeting with an invalid time', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-A',
-				'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
-				'end_date'   => '',
-				'time'       => '0100 UTC', // Some production data is formatted like this
-				'recurring'  => '',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_id = $this->factory->post->create(
+			array(
+				'post_title'  => __( 'A meeting with an invalid time', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-A',
+					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'end_date'   => '',
+					'time'       => '0100 UTC', // Some production data is formatted like this
+					'recurring'  => '',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
-
-		$meetings = $this->mpt->get_occurrences_for_period(null);
+		$meetings = $this->mpt->get_occurrences_for_period( null );
 
 		$found = 0;
 		foreach ( $meetings as $meeting ) {
@@ -84,22 +86,24 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 	}
 
 	function test_encoding() {
-		$meeting_id = $this->factory->post->create( array(
-			'post_title' => __( 'A & B meeting', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-A&B',
-				'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
-				'end_date'   => '',
-				'time'       => '01:00',
-				'recurring'  => '',
-				'link'       => '&wordpress.org',
-				'location'   => '&meta',
+		$meeting_id = $this->factory->post->create(
+			array(
+				'post_title'  => __( 'A & B meeting', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-A&B',
+					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'end_date'   => '',
+					'time'       => '01:00',
+					'recurring'  => '',
+					'link'       => '&wordpress.org',
+					'location'   => '&meta',
 				),
-		) );
+			)
+		);
 
-		$meetings = $this->mpt->get_occurrences_for_period(null);
+		$meetings = $this->mpt->get_occurrences_for_period( null );
 
 		$found = 0;
 		foreach ( $meetings as $meeting ) {
@@ -112,8 +116,6 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 			}
 		}
 		$this->assertGreaterThan( 0, $found, 'Found no meeting to test' );
-
-
 	}
 
 

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -26,71 +26,84 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 	function test_shortcode_simple() {
 
 		// A one-off meeting tomorrow
-		$meeting_1 = $this->factory->post->create( array(
-			'post_title' => __( 'Meeting One', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-F',
-				'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
-				'end_date'   => '',
-				'time'       => '01:00',
-				'recurring'  => '',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_1 = $this->factory->post->create(
+			array(
+				'post_title'  => __( 'Meeting One', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-F',
+					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'end_date'   => '',
+					'time'       => '01:00',
+					'recurring'  => '',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
 		// A recurring weekly meeting, starting yesterday
-		$meeting_1 = $this->factory->post->create( array(
-			'post_title' => __( 'Meeting Two', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-F',
-				'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
-				'end_date'   => '',
-				'time'       => '02:00',
-				'recurring'  => 'weekly',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_1 = $this->factory->post->create(
+			array(
+				'post_title'  => __( 'Meeting Two', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-F',
+					'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
+					'end_date'   => '',
+					'time'       => '02:00',
+					'recurring'  => 'weekly',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) )) );
+		$this->assertGreaterThan( 0, strpos( $actual, strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) ) ) );
 
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) )) );
+		$this->assertGreaterThan( 0, strpos( $actual, strftime( '<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) ) ) );
 	}
 
 	function test_shortcode_cancelled() {
 
 		// A recurring weekly meeting, starting yesterday
-		$meeting_1 = $this->factory->post->create( array(
-			'post_title' => __( 'Meeting One', 'wporg-meeting-calendar' ),
-			'post_type'  => 'meeting',
-			'post_status' => 'publish',
-			'meta_input' => array(
-				'team'       => 'Team-F',
-				'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
-				'end_date'   => '',
-				'time'       => '01:00',
-				'recurring'  => 'weekly',
-				'link'       => 'wordpress.org',
-				'location'   => '#meta',
+		$meeting_1 = $this->factory->post->create(
+			array(
+				'post_title'  => __( 'Meeting One', 'wporg-meeting-calendar' ),
+				'post_type'   => 'meeting',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'team'       => 'Team-F',
+					'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
+					'end_date'   => '',
+					'time'       => '01:00',
+					'recurring'  => 'weekly',
+					'link'       => 'wordpress.org',
+					'location'   => '#meta',
 				),
-		) );
+			)
+		);
 
 		// Cancel the meeting that's in 6 days
-		$response = $this->mpt->cancel_meeting( array( 'meeting_id' => $meeting_1, 'date' => strftime( '%Y-%m-%d', strtotime( 'yesterday +7 days' ) ) ) );
+		$response = $this->mpt->cancel_meeting(
+			array(
+				'meeting_id' => $meeting_1,
+				'date'       => strftime(
+					'%Y-%m-%d',
+					strtotime( 'yesterday +7 days' )
+				),
+			)
+		);
 		$this->assertGreaterThan( 0, $response );
 
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
-
 		// The shortcode should show the next meeting is in 7 days
-		$this->assertGreaterThan( 0, strpos( $actual, strftime('<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) )) );
+		$this->assertGreaterThan( 0, strpos( $actual, strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) ) ) );
 
 		// It should be listed as cancelled
 		$this->assertGreaterThanOrEqual( 0, strpos( $actual, '<p class="wporg-meeting-shortcode meeting-cancelled"' ) );

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -26,7 +26,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 	function test_shortcode_simple() {
 
 		// A one-off meeting tomorrow
-		$meeting_1 = $this->factory->post->create(
+		$this->factory->post->create(
 			array(
 				'post_title'  => __( 'Meeting One', 'wporg-meeting-calendar' ),
 				'post_type'   => 'meeting',
@@ -44,7 +44,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 		);
 
 		// A recurring weekly meeting, starting yesterday
-		$meeting_1 = $this->factory->post->create(
+		$this->factory->post->create(
 			array(
 				'post_title'  => __( 'Meeting Two', 'wporg-meeting-calendar' ),
 				'post_type'   => 'meeting',
@@ -63,9 +63,13 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
-		$this->assertGreaterThan( 0, strpos( $actual, strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) ) ) );
+		$expected = strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) );
+		$substr = substr( $actual, strpos( $actual, '<strong class="meeting-title">Meeting One</strong>' ), strlen( $expected ) );
+		$this->assertEquals( $substr, $expected );
 
-		$this->assertGreaterThan( 0, strpos( $actual, strftime( '<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) ) ) );
+		$expected = strftime( '<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) );
+		$substr = substr( $actual, strpos( $actual, '<strong class="meeting-title">Meeting Two</strong>' ), strlen( $expected ) );
+		$this->assertEquals( $substr, $expected );
 	}
 
 	function test_shortcode_cancelled() {
@@ -103,7 +107,9 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
 		// The shortcode should show the next meeting is in 7 days
-		$this->assertGreaterThan( 0, strpos( $actual, strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) ) ) );
+		$expected = strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) );
+		$substr = substr( $actual, strpos( $actual, '<strong class="meeting-title">Meeting One</strong>' ), strlen( $expected ) );
+		$this->assertEquals( $substr, $expected );
 
 		// It should be listed as cancelled
 		$this->assertGreaterThanOrEqual( 0, strpos( $actual, '<p class="wporg-meeting-shortcode meeting-cancelled"' ) );


### PR DESCRIPTION
This PR adds a wp-env environment along with composer to install phpunit and phpcs, so that the unit tests can be run locally and through a github action. Now all PRs and pushes to master will run the phpunit tests. This PR also fixes the auto-fixable phpcs issues, but there are still a number of other issues so the linter was not added to the GH workflow.

To test:

1. Check that the instructions in the readme make sense
2. Update & install the new dependencies
    `npm install`
    `composer install`
3. Start the environment `npm run wp-env start`
4. Run the tests locally `npm run test:unit-php`
5. They'll fail, but another PR (in process) will fix them

Or, watch the workflow on this PR.