### PR TITLE
Fix upcoming event date generation & sorting

### DIFF
--- a/includes/ical-functions.php
+++ b/includes/ical-functions.php
@@ -93,12 +93,18 @@ function get_meeting_posts( $team = '' ) {
 
 	$query = new \WP_Query(
 		array(
-			'post_type'   => 'meeting',
-			'post_status' => 'publish',
-			'nopaging'    => true,
-			'meta_query'  => $meta_query,
+			'post_type'        => 'meeting',
+			'post_status'      => 'publish',
+			'nopaging'         => true,
+			'meta_query'       => $meta_query,
+			// Avoid re-ordering the events.
+			'suppress_filters' => true,
 		)
 	);
 
-	return $query->get_posts();
+	$posts = $query->get_posts();
+	// Update each post with next dates – needs to be called here because we `suppress_filters` above.
+	\Meeting_Post_Type::getInstance()->meeting_set_next_meeting( $posts );
+
+	return $posts;
 }

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			add_filter( 'the_posts', array( $mpt, 'meeting_set_next_meeting' ) );
 			add_filter( 'the_posts', array( $mpt, 'meeting_sort_upcoming_meetings' ), 10, 2 );
 			add_filter( 'manage_meeting_posts_columns', array( $mpt, 'meeting_add_custom_columns' ) );
-			add_action( 'manage_meeting_posts_custom_column', array( $mpt, 'meeting_custom_columns' ), 10, 2 );
+			add_action( 'manage_meeting_posts_custom_column', array( $mpt, 'meeting_custom_columns' ), 11, 2 );
 			add_action( 'admin_head', array( $mpt, 'meeting_column_width' ) );
 			add_action( 'admin_bar_menu', array( $mpt, 'add_edit_meetings_item_to_admin_bar' ), 80 );
 			add_action( 'wp_enqueue_scripts', array( $mpt, 'add_edit_meetings_icon_to_admin_bar' ) );

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -27,7 +27,8 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			add_action( 'rest_api_init', array( $mpt, 'register_rest_routes' ) );
 			add_action( 'save_post_meeting', array( $mpt, 'save_meta_boxes' ), 10, 2 );
 			add_filter( 'pre_get_posts', array( $mpt, 'meeting_archive_page_query' ) );
-			add_filter( 'the_posts', array( $mpt, 'meeting_set_next_meeting' ), 10, 2 );
+			add_filter( 'the_posts', array( $mpt, 'meeting_set_next_meeting' ) );
+			add_filter( 'the_posts', array( $mpt, 'meeting_sort_upcoming_meetings' ), 10, 2 );
 			add_filter( 'manage_meeting_posts_columns', array( $mpt, 'meeting_add_custom_columns' ) );
 			add_action( 'manage_meeting_posts_custom_column', array( $mpt, 'meeting_custom_columns' ), 10, 2 );
 			add_action( 'admin_head', array( $mpt, 'meeting_column_width' ) );
@@ -75,8 +76,11 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			$query->set( 'meta_query', $this->meeting_meta_query() );
 		}
 
-		public function meeting_set_next_meeting( $posts, $query ) {
-			if ( ! $query->is_post_type_archive( 'meeting' ) ) {
+		public function meeting_set_next_meeting( $posts ) {
+			$is_meeting_list = array_reduce( $posts, function( $is_meeting, $post ) {
+				return $is_meeting && 'meeting' === $post->post_type;
+			}, true );
+			if ( ! $is_meeting_list ) {
 				return $posts;
 			}
 
@@ -96,6 +100,22 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 					}
 				}
 			);
+
+			return $posts;
+		}
+
+		public function meeting_sort_upcoming_meetings( $posts, $query ) {
+			// Avoid reordering posts in the admin.
+			if ( is_admin() || ! is_array( $posts ) ) {
+				return $posts;
+			}
+
+			$is_meeting_list = array_reduce( $posts, function( $is_meeting, $post ) {
+				return $is_meeting && 'meeting' === $post->post_type;
+			}, true );
+			if ( ! $is_meeting_list ) {
+				return $posts;
+			}
 
 			// reorder the posts by next_date + time
 			usort(

--- a/tests/test-ical.php
+++ b/tests/test-ical.php
@@ -1,5 +1,7 @@
 <?php
 use WordPressdotorg\Meeting_Calendar;
+use function WordPressdotorg\Meeting_Calendar\ICS\get_meeting_posts;
+use function WordPressdotorg\Meeting_Calendar\ICS\Generator\{generate, get_frequencies_by_day};
 
 /**
  * Class MeetingiCalTest
@@ -44,18 +46,8 @@ class MeetingiCalTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_ical() {
-		$posts = WordPressdotorg\Meeting_Calendar\ICS\get_meeting_posts();
-		Meeting_Post_Type::getInstance()->meeting_set_next_meeting(
-			$posts,
-			new WP_Query(
-				array(
-					'post_type' => 'meeting',
-					'nopaging'  => true,
-				)
-			)
-		);
-
-		$ical_feed  = WordPressdotorg\Meeting_Calendar\ICS\Generator\generate( $posts );
+		$posts      = get_meeting_posts();
+		$ical_feed  = generate( $posts );
 		$events_ics = file_get_contents( __DIR__ . '/fixtures/events.ics' );
 		$events_ics = str_replace( '%ID1%', str_replace( '-', '', $posts[0]->ID ), $events_ics );
 		$events_ics = str_replace( '%ID2%', str_replace( '-', '', $posts[1]->ID ), $events_ics );
@@ -68,7 +60,7 @@ class MeetingiCalTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_ical_with_cancellation() {
-		$posts = WordPressdotorg\Meeting_Calendar\ICS\get_meeting_posts( 'Team-A' );
+		$posts = get_meeting_posts( 'Team-A' );
 		// Cancel the second occurrence of the weekly meeting
 		$occurrences = Meeting_Post_Type::getInstance()->get_future_occurrences( get_post( $posts[0]->ID ), null, null );
 		$this->assertGreaterThan(
@@ -81,17 +73,7 @@ class MeetingiCalTest extends WP_UnitTestCase {
 			)
 		);
 
-		Meeting_Post_Type::getInstance()->meeting_set_next_meeting(
-			$posts,
-			new WP_Query(
-				array(
-					'post_type' => 'meeting',
-					'nopaging'  => true,
-				)
-			)
-		);
-
-		$ical_feed  = WordPressdotorg\Meeting_Calendar\ICS\Generator\generate( $posts );
+		$ical_feed  = generate( $posts );
 		$events_ics = file_get_contents( __DIR__ . '/fixtures/events-with-cancel.ics' );
 		$events_ics = str_replace( '%ID%', str_replace( '-', '', $posts[0]->ID ), $events_ics );
 		$events_ics = str_replace( '%EXDATE%', str_replace( '-', '', $occurrences[1] ), $events_ics );


### PR DESCRIPTION
Fixes #98, #5234-meta — By splitting the date generation & sorting, we can explicitly skip the event sorting when in the admin. This also fixes an issue in the tests where it _seems_ like `meeting_set_next_meeting` was not being called, because `$query->is_post_type_archive( 'meeting' )` is never true, because the meeting CPT does not have an archive. Instead of checking if it's an archive query, it now checks that every post type being filtered is a meeting. This way, the filter will also apply in the tests & iCal generation.

(based on #109, but can be re-targeted to master once that's merged)
