### PR TITLE
Calendar Export: Add a Google Calendar export option

### DIFF
--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -6,6 +6,8 @@
 // @todo: Fix these phpcs errors correctly.
 // phpcs:disable Squiz.Commenting.FunctionComment.Missing, WordPress.Security.EscapeOutput.UnsafePrintingFunction, WordPress.Security.EscapeOutput.OutputNotEscaped
 
+use function WordPressdotorg\Meeting_Calendar\ICS\Generator\get_frequency;
+
 if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 	class Meeting_Post_Type {
 
@@ -350,6 +352,11 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			$out      = array();
 			foreach ( $meetings as $meeting ) {
 				$occurrences = $this->get_future_occurrences( $meeting, null, $request );
+
+				if ( $meeting->recurring ) {
+					$frequency = get_frequency( $meeting->recurring, $occurrences[0], $meeting->occurrence );
+				}
+
 				foreach ( $occurrences as $occurrence ) {
 					$meeting->time = strftime( '%H:%M:%S', strtotime( $meeting->time ) );
 					$out[]         = array(
@@ -365,6 +372,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 						'recurring'   => $meeting->recurring,
 						'occurrence'  => $meeting->occurrence,
 						'status'      => ( $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ? 'cancelled' : 'active' ),
+						'rrule'       => $frequency ? "RRULE:FREQ={$frequency}" : '',
 					);
 				}
 			}

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -353,7 +353,8 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			foreach ( $meetings as $meeting ) {
 				$occurrences = $this->get_future_occurrences( $meeting, null, $request );
 
-				if ( $meeting->recurring ) {
+				$frequency = '';
+				if ( ! empty( $meeting->recurring ) ) {
 					$frequency = get_frequency( $meeting->recurring, $occurrences[0], $meeting->occurrence );
 				}
 

--- a/src/frontend/calendar/grid.js
+++ b/src/frontend/calendar/grid.js
@@ -1,17 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { format, gmdate } from '@wordpress/date';
 import { Fragment, useState } from '@wordpress/element';
-import { Modal, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import CalendarCell from './cell';
 import CalendarHeader from './header';
-import { getFrequencyLabel, getRows, getSlackLink, isCancelled } from './utils';
+import EventModal from './modal';
+import { getRows } from './utils';
 import { useEvents } from '../store/event-context';
 
 function CalendarGrid( { month, year } ) {
@@ -39,45 +37,10 @@ function CalendarGrid( { month, year } ) {
 				</tbody>
 			</table>
 			{ activeEvent && (
-				<Modal
-					title={ activeEvent.title }
-					className="wporg-meeting-calendar__modal"
-					overlayClassName="wporg-meeting-calendar__modal-overlay"
+				<EventModal
+					event={ activeEvent }
 					onRequestClose={ () => void setActiveEvent( null ) }
-				>
-					{ ! isCancelled( activeEvent.status ) ? (
-						<p>
-							<abbr title={ gmdate( 'c', activeEvent.datetime ) }>
-								{ format(
-									'l, F j, Y, g:i a (\\U\\T\\CP)',
-									activeEvent.datetime
-								) }
-							</abbr>
-						</p>
-					) : (
-						<Notice
-							className="wporg-meeting-calendar__modal-notice"
-							status="warning"
-							isDismissible={ false }
-						>
-							{ __( 'This meeting has been cancelled', 'wporg-meeting-calendar' ) }
-						</Notice>
-					) }
-
-					{ !! activeEvent.location && (
-						<p>
-							Location: { getSlackLink( activeEvent.location ) }
-						</p>
-					) }
-					<p>Meets: { getFrequencyLabel( activeEvent ) }</p>
-					{ !! activeEvent.link && (
-						<p>
-							<a href={ activeEvent.link }>
-								{ activeEvent.title }
-							</a>
-						</p>
-					) }
-				</Modal>
+				/>
 			) }
 		</Fragment>
 	);

--- a/src/frontend/calendar/modal.js
+++ b/src/frontend/calendar/modal.js
@@ -68,7 +68,7 @@ function EventModal( { event, onRequestClose } ) {
 					<a href={ event.link }>{ event.title }</a>
 				</p>
 			) }
-			<p>
+			<p className="wporg-meeting-calendar__modal-export-links">
 				<a href={ googleCalLink }>
 					{ __( 'Add to Google Calendar', 'wporg-meeting-calendar' ) }
 				</a>

--- a/src/frontend/calendar/modal.js
+++ b/src/frontend/calendar/modal.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { format, gmdate } from '@wordpress/date';
+import { Modal, Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { getFrequencyLabel, getSlackLink, isCancelled } from './utils';
+
+function EventModal( { event, onRequestClose } ) {
+	const start = gmdate( 'Ymd\\THis\\Z', event.datetime );
+	const endTimestamp = Number( gmdate( 'U', event.datetime ) ) + 3600;
+	const end = gmdate( 'Ymd\\THis\\Z', endTimestamp * 1000 );
+
+	const channel = event.location.replace( '#', '' );
+	let googleCalLink = addQueryArgs(
+		'https://calendar.google.com/calendar/render',
+		{
+			action: 'TEMPLATE',
+			text: event.title,
+			dates: `${ start }/${ end }`,
+			details: `Location: #${ channel } on Slack - https://wordpress.slack.com/app_redirect?channel=${ channel } `,
+		}
+	);
+	if ( event.rrule ) {
+		googleCalLink = addQueryArgs( googleCalLink, { recur: event.rrule } );
+	}
+
+	return (
+		<Modal
+			title={ event.title }
+			className="wporg-meeting-calendar__modal"
+			overlayClassName="wporg-meeting-calendar__modal-overlay"
+			onRequestClose={ onRequestClose }
+		>
+			{ ! isCancelled( event.status ) ? (
+				<p>
+					<abbr title={ gmdate( 'c', event.datetime ) }>
+						{ format(
+							'l, F j, Y, g:i a (\\U\\T\\CP)',
+							event.datetime
+						) }
+					</abbr>
+				</p>
+			) : (
+				<Notice
+					className="wporg-meeting-calendar__modal-notice"
+					status="warning"
+					isDismissible={ false }
+				>
+					{ __(
+						'This meeting has been cancelled',
+						'wporg-meeting-calendar'
+					) }
+				</Notice>
+			) }
+
+			{ !! event.location && (
+				<p>Location: { getSlackLink( event.location ) }</p>
+			) }
+			<p>Meets: { getFrequencyLabel( event ) }</p>
+			{ !! event.link && (
+				<p>
+					<a href={ event.link }>{ event.title }</a>
+				</p>
+			) }
+			<p>
+				<a href={ googleCalLink }>
+					{ __( 'Add to Google Calendar', 'wporg-meeting-calendar' ) }
+				</a>
+			</p>
+		</Modal>
+	);
+}
+
+export default EventModal;

--- a/src/frontend/filter/index.js
+++ b/src/frontend/filter/index.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, SelectControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { Button, ButtonGroup, SelectControl } from '@wordpress/components';
 import { speak } from '@wordpress/a11y';
 import { useRef } from '@wordpress/element';
 
@@ -22,11 +23,19 @@ const Filter = () => {
 	const selected = teams.find( ( option ) => team === option.value );
 
 	const getCalendarUrl = () => {
+		const baseUrl = window.location.origin;
 		if ( ! selected ) {
-			return '/meetings.ics';
+			return `${ baseUrl }/meetings.ics`;
 		}
 
-		return `/meetings-${ selected.value }.ics`;
+		return `${ baseUrl }/meetings-${ selected.value }.ics`;
+	};
+
+	const getGoogleCalendarUrl = () => {
+		const calendarUrl = getCalendarUrl().replace( 'https://', 'webcal://' );
+		return addQueryArgs( 'https://www.google.com/calendar/render', {
+			cid: calendarUrl,
+		} );
 	};
 
 	return (
@@ -43,7 +52,10 @@ const Filter = () => {
 				className="wporg-meeting-calendar__filter-dropdown"
 				value={ team }
 				options={ [
-					{ label: __( 'All teams', 'wporg-meeting-calendar' ), value: '' },
+					{
+						label: __( 'All teams', 'wporg-meeting-calendar' ),
+						value: '',
+					},
 					...teams,
 				] }
 				onChange={ ( value ) => {
@@ -53,7 +65,10 @@ const Filter = () => {
 					);
 					speak(
 						sprintf(
-							__( 'Showing meetings for %s', 'wporg-meeting-calendar' ),
+							__(
+								'Showing meetings for %s',
+								'wporg-meeting-calendar'
+							),
 							newSelected.label
 						),
 						'assertive'
@@ -64,7 +79,10 @@ const Filter = () => {
 				<>
 					<p className="wporg-meeting-calendar__filter-applied">
 						{ sprintf(
-							__( 'Showing meetings for %s', 'wporg-meeting-calendar' ),
+							__(
+								'Showing meetings for %s',
+								'wporg-meeting-calendar'
+							),
 							selected.label
 						) }
 					</p>
@@ -75,7 +93,10 @@ const Filter = () => {
 						onClick={ () => {
 							setTeam( '' );
 							speak(
-								__( 'Showing all meetings.', 'wporg-meeting-calendar' ),
+								__(
+									'Showing all meetings.',
+									'wporg-meeting-calendar'
+								),
 								'assertive'
 							);
 							filterLabel.current.focus();
@@ -86,18 +107,31 @@ const Filter = () => {
 				</>
 			) }
 			<div className="wporg-meeting-calendar__filter-feed">
-				<Button
-					icon="calendar-alt"
-					href={ getCalendarUrl() }
-					isSecondary
-					style={ {
-						marginLeft: 'auto',
-					} }
-					download
-				>
-					{ __( 'iCal', 'wporg-meeting-calendar' ) }
-					{ '' !== team && ` - ${ selected.label }` }
-				</Button>
+				<ButtonGroup label={ __( 'Export', 'wporg-meeting-calendar' ) }>
+					<Button
+						icon="calendar-alt"
+						href={ getCalendarUrl() }
+						isSecondary
+						style={ {
+							marginLeft: 'auto',
+						} }
+						download
+					>
+						{ __( 'iCal', 'wporg-meeting-calendar' ) }
+						{ '' !== team && ` - ${ selected.label }` }
+					</Button>
+					<Button
+						icon="plus"
+						href={ getGoogleCalendarUrl() }
+						isSecondary
+						style={ {
+							marginLeft: 'auto',
+						} }
+						download
+					>
+						{ __( 'Google Calendar', 'wporg-meeting-calendar' ) }
+					</Button>
+				</ButtonGroup>
 			</div>
 		</div>
 	);

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -399,6 +399,18 @@
 	margin-top: 0;
 }
 
+.wporg-meeting-calendar__filter-feed .components-button {
+	padding-right: 12px;
+}
+
+.wporg-meeting-calendar__filter-feed .components-button.has-icon .dashicon {
+	margin-right: 6px;
+}
+
+.wporg-meeting-calendar__filter-feed .components-button:first-of-type {
+	margin-right: -1px;
+}
+
 @media ( max-width: 782px ) {
 	.wporg-meeting-calendar__filter {
 		display: block;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -466,6 +466,11 @@
 .wporg-meeting-calendar__modal-notice {
 	margin: 0 0 16px 0;
 }
+
+.wporg-meeting-calendar__modal-export-links {
+	margin-top: 1em;
+}
+
 .meeting-cancelled .wporg-meeting-detail {
 	text-decoration: line-through;
 }

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -206,6 +206,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			1  =>
 			array(
@@ -221,6 +222,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'monthly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=MONTHLY',
 			),
 			2  =>
 			array(
@@ -236,6 +238,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			3  =>
 			array(
@@ -251,6 +254,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			4  =>
 			array(
@@ -269,6 +273,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 					0 => 3,
 				),
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=MONTHLY;BYDAY=3WE',
 			),
 			5  =>
 			array(
@@ -284,6 +289,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			6  =>
 			array(
@@ -299,6 +305,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			7  =>
 			array(
@@ -314,6 +321,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'monthly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=MONTHLY',
 			),
 			8  =>
 			array(
@@ -329,6 +337,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			9  =>
 			array(
@@ -344,6 +353,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			10 =>
 			array(
@@ -359,6 +369,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 			11 =>
 			array(
@@ -377,6 +388,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 					0 => 3,
 				),
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=MONTHLY;BYDAY=3WE',
 			),
 			12 =>
 			array(
@@ -392,6 +404,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'recurring'   => 'weekly',
 				'occurrence'  => '',
 				'status'      => 'active',
+				'rrule'       => 'RRULE:FREQ=WEEKLY',
 			),
 		);
 	}


### PR DESCRIPTION
This adds both a top-level button to export the current calendar view into Google Calendar, and a link to each event to add just that event (+ repeating rules).

This means people can now add the whole calendar, just a team's (Design, Meta, etc) events, or single meetings (Editor Weekly Chat, Core CSS Triage, etc).

Fixes #9, fixes #12, fixes #108.

All events:
<img width="346" alt="Screen Shot 2021-03-10 at 1 54 48 PM" src="https://user-images.githubusercontent.com/541093/110681778-30e90b00-81a8-11eb-83ea-7da6b1202bc7.png">

Just Core meetings:
<img width="365" alt="Screen Shot 2021-03-09 at 5 29 27 PM" src="https://user-images.githubusercontent.com/541093/110546854-0beb8e00-80fd-11eb-9bd2-ccac29c90bef.png">

Add a single event:
<img width="404" alt="Screen Shot 2021-03-10 at 2 16 54 PM" src="https://user-images.githubusercontent.com/541093/110684551-46abff80-81ab-11eb-8dec-8898b728431f.png">

