### PR TITLE
Enable .ics links in development environments

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,5 +2,8 @@
 	"core": "WordPress/WordPress",
 	"plugins": [
 		"."
-	]
+	],
+	"mappings": {
+		"wp-cli.yml": "./.wp-env/wp-cli.yml"
+	}
 }

--- a/.wp-env/wp-cli.yml
+++ b/.wp-env/wp-cli.yml
@@ -1,0 +1,2 @@
+apache_modules:
+  - mod_rewrite

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ You can (optionally) use [`wp-env`](https://developer.wordpress.org/block-editor
 3. Start the wp-env environment with `npm run wp-env start`
 4. Run the tests with `npm run test:unit-php`
 
+### Enable ICS links
+Calendars and individual events can be accessed through `.ics` links, for example http://localhost:8888/meetings.ics. For these links to work, the `permalink_structure` option must be set in the `wp_options` database table, and the appropriate rule must be present in `.htaccess`.
+
+You can set both with the following command:
+
+```shell
+# The --hard flag updates .htaccess rules as well as rules in the database.
+# For more info see:
+# https://developer.wordpress.org/cli/commands/rewrite/structure/
+
+wp-env run cli "wp rewrite structure --hard '/%postname%'"
+```
+
 ## License
 
 Meeting Calendar is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).


### PR DESCRIPTION
When using `wp-env` in local environments, `.ics` URLs throw a 404, for example http://localhost:8888/meetings.ics.

From what I gathered, this is due to the `permalink_option` in the `wp_options` database table being empty, which also results in an empty `.htaccess`. This in turn results in Apache not routing URLs terminated in `.ics` to PHP, instead attempting to serve the file from disk, which results in a 404 because the file does not exist.

Setting the `permalink_structure` to, for example, `/%postname%`, and then flushing the rules to `.htaccess` fixes the issue. This is what this PR does.

---
## Testing
1. Destroy any previous environments: `wp-env start` (WARNING: destroys all docker containers and volumes)
2. Create a new environment: `wp-env start`
2. Verify that http://localhost:8888/meetings.ics throws a 404
3. Run `wp-env run cli "wp rewrite structure --hard '/%postname%'"`
4. Verify that http://localhost:8888/meetings.ics returns an ICS files
